### PR TITLE
Fixed issue not finding root for mono

### DIFF
--- a/MonoDebugger.SharedLib/Server/MonoUtils.cs
+++ b/MonoDebugger.SharedLib/Server/MonoUtils.cs
@@ -45,15 +45,37 @@ namespace MonoDebugger.SharedLib.Server
             {
                 RegistryKey localMachine = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Default);
                 RegistryKey monoKey = localMachine.OpenSubKey(@"Software\Novell\Mono\");
-                var monoVersion = monoKey.GetValue("DefaultCLR") as string;
-                RegistryKey versionKey = localMachine.OpenSubKey(string.Format(@"Software\Novell\Mono\{0}", monoVersion));
-                var path = (string) versionKey.GetValue("SdkInstallRoot");
-                return path;
+                RegistryKey pathKey = null;
+
+                //try get novell key, no doubt for backward compatibility
+                if (monoKey != null)
+                {
+                    var monoVersion = monoKey.GetValue("DefaultCLR") as string;
+                     pathKey = localMachine.OpenSubKey(string.Format(@"Software\Novell\Mono\{0}", monoVersion));          
+                }
+
+                //if nothing found then get using new method
+                if(pathKey == null)
+                {
+                    pathKey = localMachine.OpenSubKey(@"Software\Mono\");
+                }
+
+                //return key or nothing if cant find
+                if (pathKey != null)
+                {
+                    return (string)pathKey.GetValue("SdkInstallRoot");
+                }
+                else
+                {
+                    return string.Empty;
+                }
+
             }
             catch
             {
+                return string.Empty;
             }
-            return string.Empty;
+            
         }
     }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 configuration: Release
 
-build:
+before_build:
   - (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\result.xml))
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 configuration: Release
 
 before_build:
-  - (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\result.xml))
+  - ps: (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\result.xml))
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,5 @@
 configuration: Release
 
-before_build:
-  - nuget restore
-
 build:
-  project: MonoDebugger.sln
-  verbosity: minimal
+  - (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\result.xml))
 
-artifacts:
-  - path: Output\Release\Extension\MonoDebugger.VS2013.vsix
-
-  - path: Output\Release\Server
-    type: zip

--- a/result.xml
+++ b/result.xml
@@ -1,0 +1,6429 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assemblies>
+  <assembly name="D:\Dev\corefx\bin\Release\System.Collections.Immutable.Tests\System.Collections.Immutable.Tests.dll" environment="32-bit .NET 4.0.30319.34014" test-framework="xUnit.net 1.9.2.1705" run-date="2014-11-15" run-time="17:25:46" total="560" passed="560" failed="0" skipped="0" time="1,885" errors="0">
+    <errors />
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.Create" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="Create" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.AddRangeBuilder" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="AddRangeBuilder" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.Clear" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="Clear" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.AddAscendingTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="AddAscendingTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.TryGetValueTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="TryGetValueTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.CreateFromEmptyEnumerableReturnsSingleton" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="CreateFromEmptyEnumerableReturnsSingleton" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.EqualsTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="EqualsTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.AddRangeDerivedBuilder" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="AddRangeDerivedBuilder" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.DictionaryIndexSetThrowsTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="DictionaryIndexSetThrowsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.KeyComparerCollisions" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="KeyComparerCollisions" time="0,024" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableStackTest.PopTest" type="System.Collections.Immutable.Test.ImmutableStackTest" method="PopTest" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.TryGetKey" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="TryGetKey" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.InsertRangeMid" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="InsertRangeMid" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.WithComparersCollisions" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="WithComparersCollisions" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.CreateRangeFromImmutableArrayWithSelectorAndArgument" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="CreateRangeFromImmutableArrayWithSelectorAndArgument" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.CustomSort" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="CustomSort" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.DictionaryIndexSetThrowsTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="DictionaryIndexSetThrowsTest" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.EmptyTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="EmptyTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.StructuralEquatableEqualsArrayInterop" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="StructuralEquatableEqualsArrayInterop" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.AddRange" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="AddRange" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.KeyComparerEmptyCollection" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="KeyComparerEmptyCollection" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.SortTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="SortTest" time="0,089" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.EmptyTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="EmptyTest" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.SortTest" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="SortTest" time="0,098" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest.IsProperSupersetOf" type="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest" method="IsProperSupersetOf" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.IndexOf" type="System.Collections.Immutable.Test.ImmutableListTest" method="IndexOf" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.GetEnumeratorTest" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="GetEnumeratorTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.RemoveRange" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="RemoveRange" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.KeyComparerCollisions" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="KeyComparerCollisions" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.SetItemUpdateEqualKeyTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="SetItemUpdateEqualKeyTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.FirstOrDefaultEmptyDefault" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="FirstOrDefaultEmptyDefault" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest.ToBuilder" type="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest" method="ToBuilder" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.GetValueOrDefaultOfConcreteType" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="GetValueOrDefaultOfConcreteType" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.AddDescendingTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="AddDescendingTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.CreateByCovariantStaticCastDefault" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="CreateByCovariantStaticCastDefault" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.Insert" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="Insert" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableQueueTest.Create" type="System.Collections.Immutable.Test.ImmutableQueueTest" method="Create" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.ExceptTest" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="ExceptTest" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.AddRangeNoOpIdentity" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="AddRangeNoOpIdentity" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.ReplaceMissingThrowsTest" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="ReplaceMissingThrowsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.AddTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="AddTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayInteropTest.DangerousGetUnderlyingArrayNegativeTests" type="System.Collections.Immutable.Test.ImmutableArrayInteropTest" method="DangerousGetUnderlyingArrayNegativeTests" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.EmptyEnumeratorReuseRegressionTest" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="EmptyEnumeratorReuseRegressionTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableStackTest.PushAndCountTest" type="System.Collections.Immutable.Test.ImmutableStackTest" method="PushAndCountTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.RemoveTest" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="RemoveTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.SingleEmptyDefault" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="SingleEmptyDefault" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.Select" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="Select" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.AggregateEmpty" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="AggregateEmpty" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.NullHandlingTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="NullHandlingTest" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.ToImmutableArray" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="ToImmutableArray" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.ToSortedTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="ToSortedTest" time="0,025" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.IsSubsetOfTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="IsSubsetOfTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest.UnionWith" type="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest" method="UnionWith" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.IDictionaryMembers" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="IDictionaryMembers" time="0,009" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.WithComparersEmptyCollection" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="WithComparersEmptyCollection" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.ICollectionMembers" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="ICollectionMembers" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.BinarySearch" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="BinarySearch" time="0,038" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.IndexOf" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="IndexOf" time="0,033" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.IDictionaryEnumerator" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="IDictionaryEnumerator" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.GetEnumeratorTest" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="GetEnumeratorTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableInterlockedTests.EnqueueQueue" type="System.Collections.Immutable.Test.ImmutableInterlockedTests" method="EnqueueQueue" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.IListOfTIsReadOnly" type="System.Collections.Immutable.Test.ImmutableListTest" method="IListOfTIsReadOnly" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.CopyTo" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="CopyTo" time="0,010" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableInterlockedTests.InterlockedCompareExchangeArray" type="System.Collections.Immutable.Test.ImmutableInterlockedTests" method="InterlockedCompareExchangeArray" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.ContainsPair" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="ContainsPair" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.Remove" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="Remove" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.ICollectionOfTMethods" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="ICollectionOfTMethods" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.SetItem" type="System.Collections.Immutable.Test.ImmutableListTest" method="SetItem" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.OverlapsTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="OverlapsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.GetHashCodeVariesByInstance" type="System.Collections.Immutable.Test.ImmutableListTest" method="GetHashCodeVariesByInstance" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.CopyToEmptyTest" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="CopyToEmptyTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.SingleOrDefaultEmptyDefault" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="SingleOrDefaultEmptyDefault" time="0,000" result="Pass" />
+    </collection>
+    <collection total="560" passed="560" failed="0" skipped="0" name="xUnit.net v1 Tests for D:\Dev\corefx\bin\Release\System.Collections.Immutable.Tests\System.Collections.Immutable.Tests.dll" time="1,885">
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.CreateBuilderDefaultCapacity" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="CreateBuilderDefaultCapacity" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest.KeyComparerEmptyCollection" type="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest" method="KeyComparerEmptyCollection" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.IndexOfDefault" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="IndexOfDefault" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.BuilderFromMap" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="BuilderFromMap" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableInterlockedTests.AddOrUpdateDictionaryAddValueFactory" type="System.Collections.Immutable.Test.ImmutableInterlockedTests" method="AddOrUpdateDictionaryAddValueFactory" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.UnionWith" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="UnionWith" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.LastIndexOf" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="LastIndexOf" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.IsReadOnly" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="IsReadOnly" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.Clear" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="Clear" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.ICollectionMethods" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="ICollectionMethods" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.OperatorsAndEquality" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="OperatorsAndEquality" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.InsertRangeLeft" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="InsertRangeLeft" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.BuilderReusesUnchangedImmutableInstances" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="BuilderReusesUnchangedImmutableInstances" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.SyncRoot" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="SyncRoot" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableQueueTest.EnumeratorRecyclingMisuse" type="System.Collections.Immutable.Test.ImmutableQueueTest" method="EnumeratorRecyclingMisuse" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.Create" type="System.Collections.Immutable.Test.ImmutableListTest" method="Create" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.SymmetricExceptTest" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="SymmetricExceptTest" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.ToImmutableSortedDictionary" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="ToImmutableSortedDictionary" time="0,007" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.StructuralEquatableGetHashCode" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="StructuralEquatableGetHashCode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.ICollectionOfTMembers" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="ICollectionOfTMembers" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.EqualsTest" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="EqualsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.Indexer" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="Indexer" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.AddRangeTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="AddRangeTest" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.ClearTest" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="ClearTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.WithComparers" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="WithComparers" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.IsProperSupersetOf" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="IsProperSupersetOf" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.CreateRangeSliceFromImmutableArrayWithSelectorAndArgument" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="CreateRangeSliceFromImmutableArrayWithSelectorAndArgument" time="0,006" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.EnumeratorTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="EnumeratorTest" time="0,118" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest.ICollectionOfTMethods" type="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest" method="ICollectionOfTMethods" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.ToBuilder" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="ToBuilder" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.ToBuilder" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="ToBuilder" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.TryGetKey" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="TryGetKey" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.KeyComparerEmptyCollection" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="KeyComparerEmptyCollection" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.RemoveNonExistentKeepsReference" type="System.Collections.Immutable.Test.ImmutableListTest" method="RemoveNonExistentKeepsReference" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.Keys" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="Keys" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.IntersectWith" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="IntersectWith" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.BuilderReusesUnchangedImmutableInstances" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="BuilderReusesUnchangedImmutableInstances" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.GetHashCodeTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="GetHashCodeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.SetItemTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="SetItemTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.CountContract" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="CountContract" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.Clear" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="Clear" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.AddRangeDerivedArray" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="AddRangeDerivedArray" time="0,131" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.ReverseTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="ReverseTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.EnumeratorRecyclingMisuse" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="EnumeratorRecyclingMisuse" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.GetEnumeratorExplicit" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="GetEnumeratorExplicit" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.ReverseTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="ReverseTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.ClearTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="ClearTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.LastEmptyDefault" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="LastEmptyDefault" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.RequiresTests.NotNullAllowStructs" type="System.Collections.Immutable.Test.RequiresTests" method="NotNullAllowStructs" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.FirstOrDefaultEmpty" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="FirstOrDefaultEmpty" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.GetValueOrDefaultOfConcreteType" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="GetValueOrDefaultOfConcreteType" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.AddTest" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="AddTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.Create" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="Create" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.WithComparers" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="WithComparers" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.SortComparer" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="SortComparer" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.AddExistingKeyWithDifferentValue" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="AddExistingKeyWithDifferentValue" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.RemoveKey" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="RemoveKey" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.Enumerator" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="Enumerator" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.SetItem" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="SetItem" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest.IsProperSubsetOf" type="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest" method="IsProperSubsetOf" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.Values" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="Values" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.CovarianceImplicit" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="CovarianceImplicit" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableInterlockedTests.TryAddDictionary" type="System.Collections.Immutable.Test.ImmutableInterlockedTests" method="TryAddDictionary" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.ToUnorderedTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="ToUnorderedTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.RemoveAt" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="RemoveAt" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.EnumeratorWithNullValues" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="EnumeratorWithNullValues" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.CreateBuilderInvalidCapacity" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="CreateBuilderInvalidCapacity" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.Indexer" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="Indexer" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.Insert" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="Insert" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.FindAllTest" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="FindAllTest" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.ElementAt" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="ElementAt" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.Add" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="Add" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.IListMethods" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="IListMethods" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest.KeyComparer" type="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest" method="KeyComparer" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.Last" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="Last" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest.BuilderFromSet" type="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest" method="BuilderFromSet" time="0,012" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.SingleOrDefault" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="SingleOrDefault" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.AddRemoveRandomDataTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="AddRemoveRandomDataTest" time="0,010" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.RemoveRangeEnumerableTest" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="RemoveRangeEnumerableTest" time="0,011" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.ContainsTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="ContainsTest" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.ContainsValue" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="ContainsValue" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableInterlockedTests.GetOrAddDictionaryValue" type="System.Collections.Immutable.Test.ImmutableInterlockedTests" method="GetOrAddDictionaryValue" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.Overlaps" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="Overlaps" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.AddExistingKeyWithDifferentValue" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="AddExistingKeyWithDifferentValue" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.IsSupersetOfTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="IsSupersetOfTest" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.SeveralChanges" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="SeveralChanges" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.RemoveTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="RemoveTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest.EnumeratorTest" type="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest" method="EnumeratorTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableInterlockedTests.GetOrAddDictionaryValueFactoryWithArg" type="System.Collections.Immutable.Test.ImmutableInterlockedTests" method="GetOrAddDictionaryValueFactoryWithArg" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.IndexOf" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="IndexOf" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableInterlockedTests.InterlockedExchangeArrayDefault" type="System.Collections.Immutable.Test.ImmutableInterlockedTests" method="InterlockedExchangeArrayDefault" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.ReverseTest" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="ReverseTest" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.FindTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="FindTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.TryGetValue" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="TryGetValue" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.IDictionaryOfKVMembers" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="IDictionaryOfKVMembers" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.CreateFromArray" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="CreateFromArray" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.ToSortTest" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="ToSortTest" time="0,020" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.NormalConstructionValueType" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="NormalConstructionValueType" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.SetItemUpdateEqualKeyWithValueEqualityByComparer" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="SetItemUpdateEqualKeyWithValueEqualityByComparer" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.CreateRangeSliceFromImmutableArrayWithSelector" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="CreateRangeSliceFromImmutableArrayWithSelector" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.GetValueOrDefaultOfIImmutableDictionary" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="GetValueOrDefaultOfIImmutableDictionary" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableInterlockedTests.TryPopStack" type="System.Collections.Immutable.Test.ImmutableInterlockedTests" method="TryPopStack" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.AddRemoveLoadTest" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="AddRemoveLoadTest" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.EnumeratorTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="EnumeratorTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.RequiresTests.Range" type="System.Collections.Immutable.Test.RequiresTests" method="Range" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.ContainsValueTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="ContainsValueTest" time="0,006" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.AddBulkFromImmutableToEmpty" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="AddBulkFromImmutableToEmpty" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.IsDefaultOrEmpty" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="IsDefaultOrEmpty" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.AddRemoveEnumerableTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="AddRemoveEnumerableTest" time="0,010" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.RemoveRangeEnumerableTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="RemoveRangeEnumerableTest" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest.SymmetricExceptWith" type="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest" method="SymmetricExceptWith" time="0,008" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.RemoveNonExistingTest" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="RemoveNonExistingTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest.KeyComparerCollisions" type="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest" method="KeyComparerCollisions" time="0,008" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.LastEmpty" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="LastEmpty" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest.IsSupersetOf" type="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest" method="IsSupersetOf" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.AddExistingKeyDifferentValueTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="AddExistingKeyDifferentValueTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.Single" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="Single" time="0,015" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableInterlockedTests.TryRemoveDictionary" type="System.Collections.Immutable.Test.ImmutableInterlockedTests" method="TryRemoveDictionary" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.EnumerateBuilderWhileMutating" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="EnumerateBuilderWhileMutating" time="0,011" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableInterlockedTests.PushStack" type="System.Collections.Immutable.Test.ImmutableInterlockedTests" method="PushStack" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.ExplicitMethods" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="ExplicitMethods" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.RemoveValuesFromCollidedHashCode" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="RemoveValuesFromCollidedHashCode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.RemoveAllNullTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="RemoveAllNullTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.IsReadOnly" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="IsReadOnly" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.GetRangeTest" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="GetRangeTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.EnumerateBuilderWhileMutating" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="EnumerateBuilderWhileMutating" time="0,017" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest.Remove" type="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest" method="Remove" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.IsSynchronized" type="System.Collections.Immutable.Test.ImmutableListTest" method="IsSynchronized" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.FindAllTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="FindAllTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.LastIndexOf" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="LastIndexOf" time="0,009" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.EnumerateBuilderWhileMutating" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="EnumerateBuilderWhileMutating" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.TryGetValueTest" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="TryGetValueTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.IsProperSubsetOfTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="IsProperSubsetOfTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.Indexer" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="Indexer" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.ObjectEnumerator" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="ObjectEnumerator" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.LastIndexOf" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="LastIndexOf" time="0,008" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.IListMembers" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="IListMembers" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.IndexGetTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="IndexGetTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.IsReadOnly" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="IsReadOnly" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableQueueTest.PeekEmptyThrows" type="System.Collections.Immutable.Test.ImmutableQueueTest" method="PeekEmptyThrows" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.CreateFromNullArray" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="CreateFromNullArray" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.IsEmpty" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="IsEmpty" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.ValuesTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="ValuesTest" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.Sort" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="Sort" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.SortComparer" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="SortComparer" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.AddRange" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="AddRange" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.ExistsTest" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="ExistsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.IsSubsetOf" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="IsSubsetOf" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.UnionOptimizationsTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="UnionOptimizationsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.RemoveTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="RemoveTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.ContainsKeyTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="ContainsKeyTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.CreateFromSliceOfArrayEmptyReturnsSingleton" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="CreateFromSliceOfArrayEmptyReturnsSingleton" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.CreateFromSliceOfImmutableArrayOptimizations" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="CreateFromSliceOfImmutableArrayOptimizations" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.ToArray" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="ToArray" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.LastIndexOfDefault" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="LastIndexOfDefault" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.AddDuplicatesTest" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="AddDuplicatesTest" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.ICollectionOfKVMembers" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="ICollectionOfKVMembers" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.MutationsSucceedAfterToImmutable" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="MutationsSucceedAfterToImmutable" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableInterlockedTests.TryUpdateDictionary" type="System.Collections.Immutable.Test.ImmutableInterlockedTests" method="TryUpdateDictionary" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.Aggregate" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="Aggregate" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.GetHashCodeTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="GetHashCodeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.IDictionaryEnumerator" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="IDictionaryEnumerator" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.IndexGetTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="IndexGetTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.ISetMutationMethods" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="ISetMutationMethods" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.LastOrDefault" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="LastOrDefault" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.IsProperSubsetOf" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="IsProperSubsetOf" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.IDictionaryEnumerator" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="IDictionaryEnumerator" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.IndexGetNonExistingKeyThrowsTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="IndexGetNonExistingKeyThrowsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.FindLastIndexTest" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="FindLastIndexTest" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.FindTest" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="FindTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.AnyEmptyDefault" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="AnyEmptyDefault" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.IndexOfAndContainsTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="IndexOfAndContainsTest" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.Any" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="Any" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.EnumeratorRecyclingMisuse" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="EnumeratorRecyclingMisuse" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.ISetMutationMethods" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="ISetMutationMethods" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.Remove" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="Remove" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.Values" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="Values" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.RemoveRange" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="RemoveRange" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableQueueTest.EnqueueDequeueTest" type="System.Collections.Immutable.Test.ImmutableQueueTest" method="EnqueueDequeueTest" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.IsProperSupersetOfTest" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="IsProperSupersetOfTest" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.EmptyTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="EmptyTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.SetItemTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="SetItemTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.FindLastTest" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="FindLastTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.CreateFromSliceOfImmutableArray" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="CreateFromSliceOfImmutableArray" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.AllEmptyDefault" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="AllEmptyDefault" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.IListIsReadOnly" type="System.Collections.Immutable.Test.ImmutableListTest" method="IListIsReadOnly" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.ElementAtOrDefault" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="ElementAtOrDefault" time="0,012" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.RequiresTests.FailRange" type="System.Collections.Immutable.Test.RequiresTests" method="FailRange" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.InsertRangeDefaultStruct" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="InsertRangeDefaultStruct" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.IndexGetter" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="IndexGetter" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.MaxMin" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="MaxMin" time="0,012" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.FindIndexTest" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="FindIndexTest" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.IndexGetTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="IndexGetTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.GetHashCodeTest" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="GetHashCodeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.BuilderFromSet" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="BuilderFromSet" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.FirstEmptyDefault" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="FirstEmptyDefault" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.ChangeSortComparer" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="ChangeSortComparer" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.FirstEmpty" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="FirstEmpty" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.KeyComparer" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="KeyComparer" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.FindLastIndexTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="FindLastIndexTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableInterlockedTests.AddOrUpdateDictionaryAddValue" type="System.Collections.Immutable.Test.ImmutableInterlockedTests" method="AddOrUpdateDictionaryAddValue" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.ToBuilder" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="ToBuilder" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.Replace" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="Replace" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.ToImmutableDictionary" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="ToImmutableDictionary" time="0,031" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.FindLastTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="FindLastTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableStackTest.EmptyTest" type="System.Collections.Immutable.Test.ImmutableStackTest" method="EmptyTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.IndexSetter" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="IndexSetter" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.ICollectionOfTMethods" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="ICollectionOfTMethods" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.WhereEmptyDefault" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="WhereEmptyDefault" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.SingleOrDefaultEmpty" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="SingleOrDefaultEmpty" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.Enumerator" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="Enumerator" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.ICollectionOfKVMembers" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="ICollectionOfKVMembers" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.AddAscendingTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="AddAscendingTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.AddExactDuplicate" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="AddExactDuplicate" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.BuilderFromList" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="BuilderFromList" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.CreateRangeFromImmutableArrayWithSelector" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="CreateRangeFromImmutableArrayWithSelector" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.ICollectionMembers" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="ICollectionMembers" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.ContainsValue" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="ContainsValue" time="0,015" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.Indexer" type="System.Collections.Immutable.Test.ImmutableListTest" method="Indexer" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.GetValueOrDefaultOfConcreteType" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="GetValueOrDefaultOfConcreteType" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.CopyToTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="CopyToTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.ExceptWith" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="ExceptWith" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.IsProperSubsetOfTest" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="IsProperSubsetOfTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.AggregateEmptyDefault" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="AggregateEmptyDefault" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.SetItemsTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="SetItemsTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.RemoveTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="RemoveTest" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.LastIndexOf" type="System.Collections.Immutable.Test.ImmutableListTest" method="LastIndexOf" time="0,006" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.TrueForAllTest" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="TrueForAllTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.LastOrDefaultEmpty" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="LastOrDefaultEmpty" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.Reverse" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="Reverse" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.IListOfTMethods" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="IListOfTMethods" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.AddRemoveEnumerableTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="AddRemoveEnumerableTest" time="0,007" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableInterlockedTests.InterlockedCompareExchangeArrayDefault" type="System.Collections.Immutable.Test.ImmutableInterlockedTests" method="InterlockedCompareExchangeArrayDefault" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.ValuesTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="ValuesTest" time="0,022" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.EqualsTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="EqualsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.SyncRoot" type="System.Collections.Immutable.Test.ImmutableListTest" method="SyncRoot" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.AddRangeDefaultStruct" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="AddRangeDefaultStruct" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.EnumeratorWithHashCollisionsTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="EnumeratorWithHashCollisionsTest" time="0,014" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableStackTest.EqualityTest" type="System.Collections.Immutable.Test.ImmutableStackTest" method="EqualityTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.RemoveRangeArrayTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="RemoveRangeArrayTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.ConvertAllTest" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="ConvertAllTest" time="0,016" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.EnumeratorWithHashCollisionsTest" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="EnumeratorWithHashCollisionsTest" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.RemoveAt" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="RemoveAt" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.InsertRangeNoOpIdentity" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="InsertRangeNoOpIdentity" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.AddRangeDefaultEnumerable" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="AddRangeDefaultEnumerable" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.ICollectionMethods" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="ICollectionMethods" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.IndexGetNonExistingKeyThrowsTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="IndexGetNonExistingKeyThrowsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableQueueTest.DequeueOutValue" type="System.Collections.Immutable.Test.ImmutableQueueTest" method="DequeueOutValue" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.IDictionaryOfKVMembers" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="IDictionaryOfKVMembers" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.MaxTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="MaxTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.Add" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="Add" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.EnumerateTest" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="EnumerateTest" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayInteropTest.DangerousGetUnderlyingArray" type="System.Collections.Immutable.Test.ImmutableArrayInteropTest" method="DangerousGetUnderlyingArray" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.RemoveKey" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="RemoveKey" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.RandomOperationsTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="RandomOperationsTest" time="0,019" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.KeyComparerCollisions" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="KeyComparerCollisions" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.RequiresTests.Argument" type="System.Collections.Immutable.Test.RequiresTests" method="Argument" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.DictionaryAddThrowsTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="DictionaryAddThrowsTest" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.RemoveAtTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="RemoveAtTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.Covariance" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="Covariance" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest.IsSubsetOf" type="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest" method="IsSubsetOf" time="0,009" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.SelectEmptyDefault" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="SelectEmptyDefault" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableInterlockedTests.TryDequeueQueue" type="System.Collections.Immutable.Test.ImmutableInterlockedTests" method="TryDequeueQueue" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.BinarySearchPartialSortedList" type="System.Collections.Immutable.Test.ImmutableListTest" method="BinarySearchPartialSortedList" time="0,028" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.AddRemoveRandomDataTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="AddRemoveRandomDataTest" time="0,023" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.StructuralEquatableEqualsDefault" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="StructuralEquatableEqualsDefault" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.AddExistingKeySameValueTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="AddExistingKeySameValueTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.BuilderReusesUnchangedImmutableInstances" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="BuilderReusesUnchangedImmutableInstances" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.OverlapsTest" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="OverlapsTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.IDictionaryMembers" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="IDictionaryMembers" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.Count" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="Count" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.CreateFromSliceOfArray" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="CreateFromSliceOfArray" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.RemovePair" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="RemovePair" time="0,023" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.SetItemsTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="SetItemsTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.Create" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="Create" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.Insert" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="Insert" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.AddRangeIEnumerable" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="AddRangeIEnumerable" time="0,021" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.StructuralEquatableEquals" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="StructuralEquatableEquals" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.EqualsTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="EqualsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.ContainsEqualityComparer" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="ContainsEqualityComparer" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.ReplaceTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="ReplaceTest" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.Indexer" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="Indexer" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.ChangeUnorderedEqualityComparer" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="ChangeUnorderedEqualityComparer" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.EqualsObjectNull" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="EqualsObjectNull" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.All" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="All" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.StructuralEquatableGetHashCodeDefault" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="StructuralEquatableGetHashCodeDefault" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.FirstOrDefault" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="FirstOrDefault" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.CreateByCovariantStaticCast" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="CreateByCovariantStaticCast" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.SymmetricExceptWith" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="SymmetricExceptWith" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.KeyComparer" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="KeyComparer" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.SelectEmpty" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="SelectEmpty" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.DictionaryAddThrowsTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="DictionaryAddThrowsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.ConvertAllTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="ConvertAllTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.EmptyTest" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="EmptyTest" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.IntersectTest" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="IntersectTest" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.GetHashCodeTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="GetHashCodeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.ToBuilder" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="ToBuilder" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.ToBuilder" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="ToBuilder" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableStackTest.EmptyPopThrows" type="System.Collections.Immutable.Test.ImmutableStackTest" method="EmptyPopThrows" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.First" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="First" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.ToImmutableDictionaryOptimized" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="ToImmutableDictionaryOptimized" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.MinTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="MinTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.CreateBuilder" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="CreateBuilder" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.SequenceEqual" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="SequenceEqual" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.UnorderedChangeTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="UnorderedChangeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.ContainsValueTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="ContainsValueTest" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableQueueTest.ClearTest" type="System.Collections.Immutable.Test.ImmutableQueueTest" method="ClearTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.SetEqualsTest" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="SetEqualsTest" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.ICollectionOfTMembers" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="ICollectionOfTMembers" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.Count" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="Count" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.GetRangeTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="GetRangeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.ReverseTest2" type="System.Collections.Immutable.Test.ImmutableListTest" method="ReverseTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.Clear" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="Clear" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.SortChangeTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="SortChangeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.EnumerateBuilderWhileMutating" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="EnumerateBuilderWhileMutating" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.CreateBuilder" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="CreateBuilder" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.RemovePair" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="RemovePair" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.DictionaryRemoveThrowsTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="DictionaryRemoveThrowsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.CustomSort" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="CustomSort" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest.Overlaps" type="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest" method="Overlaps" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.RemoveRangeNoOpIdentity" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="RemoveRangeNoOpIdentity" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.ContainsPair" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="ContainsPair" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.Remove" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="Remove" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.Contains" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="Contains" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.Keys" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="Keys" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.InitialBulkAdd" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="InitialBulkAdd" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.AddRange" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="AddRange" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.IsSubsetOfTest" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="IsSubsetOfTest" time="0,009" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.ToUnorderedTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="ToUnorderedTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.EnumeratorRecyclingMisuse" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="EnumeratorRecyclingMisuse" time="0,013" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.SeveralChanges" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="SeveralChanges" time="0,009" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.AnyEmpty" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="AnyEmpty" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.EnumerateTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="EnumerateTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.Create" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="Create" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.RemoveAll" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="RemoveAll" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.BinarySearch" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="BinarySearch" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.CopyToEmptyTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="CopyToEmptyTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.ICollectionMembers" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="ICollectionMembers" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.AddAndIndexerTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="AddAndIndexerTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.Add" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="Add" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.IDictionaryMembers" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="IDictionaryMembers" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.TryGetValue" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="TryGetValue" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.SymmetricExceptTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="SymmetricExceptTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.ToImmutableSortedSetTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="ToImmutableSortedSetTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.IndexOfTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="IndexOfTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.TryGetKey" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="TryGetKey" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.RandomOperationsTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="RandomOperationsTest" time="0,010" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.CopyToTest" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="CopyToTest" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.EnumeratorRecyclingMisuse" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="EnumeratorRecyclingMisuse" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.AddDescendingTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="AddDescendingTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.AddExistingKeySameValueTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="AddExistingKeySameValueTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.InsertDefault" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="InsertDefault" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.CreateBuilder" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="CreateBuilder" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.UnionTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="UnionTest" time="0,046" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.ICollectionMembers" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="ICollectionMembers" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.AddRangeDerivedImmutableArray" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="AddRangeDerivedImmutableArray" time="0,007" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.EnumeratorTest" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="EnumeratorTest" time="0,129" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.AddRangeTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="AddRangeTest" time="0,006" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.StructuralComparableArrayInterop" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="StructuralComparableArrayInterop" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.InitialBulkAddWithKeyCollisionTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="InitialBulkAddWithKeyCollisionTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.GetEnumeratorTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="GetEnumeratorTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.DowncastOfDefaultStructs" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="DowncastOfDefaultStructs" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.EnumeratorTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="EnumeratorTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.SortPreservesArrayWhenAlreadySorted" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="SortPreservesArrayWhenAlreadySorted" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.DictionaryRemoveThrowsTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="DictionaryRemoveThrowsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.EmptyTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="EmptyTest" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.Contains" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="Contains" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.SetEqualsTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="SetEqualsTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.RemoveAt" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="RemoveAt" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.ToImmutable" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="ToImmutable" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.WithComparersEmptyCollection" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="WithComparersEmptyCollection" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableQueueTest.DequeueEmptyThrows" type="System.Collections.Immutable.Test.ImmutableQueueTest" method="DequeueEmptyThrows" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.FindIndexTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="FindIndexTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.InsertRange" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="InsertRange" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.KeyComparerEmptyCollection" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="KeyComparerEmptyCollection" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.ReplaceWithEqualityComparerTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="ReplaceWithEqualityComparerTest" time="0,008" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.Add" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="Add" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.ToDictionary" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="ToDictionary" time="0,009" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.SeveralChanges" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="SeveralChanges" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.IsSupersetOf" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="IsSupersetOf" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.BinarySearch" type="System.Collections.Immutable.Test.ImmutableListTest" method="BinarySearch" time="0,027" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.SequenceEqualEmpty" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="SequenceEqualEmpty" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.ForEachTest" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="ForEachTest" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.AddRangeOptimizationsTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="AddRangeOptimizationsTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.BuilderReusesUnchangedImmutableInstances" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="BuilderReusesUnchangedImmutableInstances" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.KeysTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="KeysTest" time="0,010" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.InitialBulkAddUniqueTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="InitialBulkAddUniqueTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.EnumeratorRecyclingMisuse" type="System.Collections.Immutable.Test.ImmutableListTest" method="EnumeratorRecyclingMisuse" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.ExceptTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="ExceptTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.InsertTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="InsertTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.ReverseContents" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="ReverseContents" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.CreateBuilder" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="CreateBuilder" time="0,006" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.CreateFromEnumerable" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="CreateFromEnumerable" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.IsProperSupersetOfTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="IsProperSupersetOfTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.AddDuplicatesTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="AddDuplicatesTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.AllEmpty" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="AllEmpty" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.AddBulkFromImmutableToEmpty" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="AddBulkFromImmutableToEmpty" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.AddExactDuplicate" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="AddExactDuplicate" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayInteropTest.DangerousCreateFromUnderlyingArray" type="System.Collections.Immutable.Test.ImmutableArrayInteropTest" method="DangerousCreateFromUnderlyingArray" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.ToImmutableList" type="System.Collections.Immutable.Test.ImmutableListTest" method="ToImmutableList" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableStackTest.EnumeratorTest" type="System.Collections.Immutable.Test.ImmutableStackTest" method="EnumeratorTest" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.ConcatEdgeCases" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="ConcatEdgeCases" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.AddRemoveLoadTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="AddRemoveLoadTest" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest.Clear" type="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest" method="Clear" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.RandomOperationsTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="RandomOperationsTest" time="0,009" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest.IntersectWith" type="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest" method="IntersectWith" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.InsertRangeDefault" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="InsertRangeDefault" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableQueueTest.GetEnumeratorText" type="System.Collections.Immutable.Test.ImmutableQueueTest" method="GetEnumeratorText" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.InsertRangeRight" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="InsertRangeRight" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.IEnumerator" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="IEnumerator" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.LastOrDefaultEmptyDefault" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="LastOrDefaultEmptyDefault" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayInteropTest.DangerousCreateFromUnderlyingArrayNegativeTests" type="System.Collections.Immutable.Test.ImmutableArrayInteropTest" method="DangerousCreateFromUnderlyingArrayNegativeTests" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableQueueTest.EnumerationOrder" type="System.Collections.Immutable.Test.ImmutableQueueTest" method="EnumerationOrder" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.GetHashCodeTest" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="GetHashCodeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.StructuralComparable" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="StructuralComparable" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.ReplaceMissingThrowsTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="ReplaceMissingThrowsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.StructuralComparableDefault" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="StructuralComparableDefault" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableInterlockedTests.InterlockedInitializeArray" type="System.Collections.Immutable.Test.ImmutableInterlockedTests" method="InterlockedInitializeArray" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.Concat" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="Concat" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.CopyToIntArrayIntInt" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="CopyToIntArrayIntInt" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.RemoveRange" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="RemoveRange" time="0,010" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.CopyToArray" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="CopyToArray" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.ForEachTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="ForEachTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.ContainsKeyTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="ContainsKeyTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.AddRangeImmutableArray" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="AddRangeImmutableArray" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.CreateEmpty" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="CreateEmpty" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.Remove" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="Remove" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.AddExistingKeyDifferentValueTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="AddExistingKeyDifferentValueTest" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.Sort" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="Sort" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.EnumeratorTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="EnumeratorTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.IDictionaryMembers" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="IDictionaryMembers" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.IntersectTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="IntersectTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.TrueForAllTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="TrueForAllTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.ContainsTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="ContainsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.IsDefault" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="IsDefault" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.SortRange" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="SortRange" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.IndexOf" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="IndexOf" time="0,006" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableStackTest.PeekTest" type="System.Collections.Immutable.Test.ImmutableStackTest" method="PeekTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.RequiresTests.NotNull" type="System.Collections.Immutable.Test.RequiresTests" method="NotNull" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.ICollectionMethods" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="ICollectionMethods" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.Clear" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="Clear" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableInterlockedTests.InterlockedExchangeArrayNonDefault" type="System.Collections.Immutable.Test.ImmutableInterlockedTests" method="InterlockedExchangeArrayNonDefault" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.RemoveAllTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="RemoveAllTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.Where" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="Where" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableStackTest.EmptyPeekThrows" type="System.Collections.Immutable.Test.ImmutableStackTest" method="EmptyPeekThrows" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.Reverse" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="Reverse" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.UnionTest" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="UnionTest" time="0,044" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.AddRange" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="AddRange" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.EqualityCheckComparesInternalArrayByReference" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="EqualityCheckComparesInternalArrayByReference" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.KeyComparer" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="KeyComparer" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.SequenceEqualEmptyDefault" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="SequenceEqualEmptyDefault" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.RemoveAllTest" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="RemoveAllTest" time="0,006" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetTest.IsSupersetOfTest" type="System.Collections.Immutable.Test.ImmutableHashSetTest" method="IsSupersetOfTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.NormalConstructionRefType" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="NormalConstructionRefType" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest.EnumerateBuilderWhileMutating" type="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest" method="EnumerateBuilderWhileMutating" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest.BuilderReusesUnchangedImmutableInstances" type="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest" method="BuilderReusesUnchangedImmutableInstances" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.BuilderFromMap" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="BuilderFromMap" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.RemoveTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="RemoveTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.CreateFromSliceOfImmutableArrayEmptyReturnsSingleton" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="CreateFromSliceOfImmutableArrayEmptyReturnsSingleton" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.NullableOperators" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="NullableOperators" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest.SetEquals" type="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest" method="SetEquals" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.KeysTest" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="KeysTest" time="0,006" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.SingleEmpty" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="SingleEmpty" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest.CopyTo" type="System.Collections.Immutable.Test.ImmutableDictionaryBuilderTest" method="CopyTo" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest.WhereEmpty" type="System.Collections.Immutable.Test.ImmutableArrayExtensionsTest" method="WhereEmpty" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest.CreateBuilder" type="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest" method="CreateBuilder" time="0,013" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableQueueTest.EqualsTest" type="System.Collections.Immutable.Test.ImmutableQueueTest" method="EqualsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableStackTest.PopOutValue" type="System.Collections.Immutable.Test.ImmutableStackTest" method="PopOutValue" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.BinarySearchPartialSortedList" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="BinarySearchPartialSortedList" time="0,033" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.RemoveRangeDefaultStruct" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="RemoveRangeDefaultStruct" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableQueueTest.Empty" type="System.Collections.Immutable.Test.ImmutableQueueTest" method="Empty" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.InitialBulkAddWithExactDuplicatesTest" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="InitialBulkAddWithExactDuplicatesTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.OfType" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="OfType" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayTest.InsertRangeEmpty" type="System.Collections.Immutable.Test.ImmutableArrayTest" method="InsertRangeEmpty" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListBuilderTest.IsSynchronized" type="System.Collections.Immutable.Test.ImmutableListBuilderTest" method="IsSynchronized" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest.TryGetKey" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryTest" method="TryGetKey" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableStackTest.Create" type="System.Collections.Immutable.Test.ImmutableStackTest" method="Create" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.ToImmutableListOfSameType" type="System.Collections.Immutable.Test.ImmutableListTest" method="ToImmutableListOfSameType" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.InsertRangeTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="InsertRangeTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.ExistsTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="ExistsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest.SetEquals" type="System.Collections.Immutable.Test.ImmutableSortedSetBuilderTest" method="SetEquals" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableDictionaryTest.WithComparersCollisions" type="System.Collections.Immutable.Test.ImmutableDictionaryTest" method="WithComparersCollisions" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableArrayBuilderTest.SortRange" type="System.Collections.Immutable.Test.ImmutableArrayBuilderTest" method="SortRange" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableListTest.EqualsTest" type="System.Collections.Immutable.Test.ImmutableListTest" method="EqualsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest.ExceptWith" type="System.Collections.Immutable.Test.ImmutableHashSetBuilderTest" method="ExceptWith" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedSetTest.RemoveNonExistingTest" type="System.Collections.Immutable.Test.ImmutableSortedSetTest" method="RemoveNonExistingTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableInterlockedTests.GetOrAddDictionaryValueFactory" type="System.Collections.Immutable.Test.ImmutableInterlockedTests" method="GetOrAddDictionaryValueFactory" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest.IDictionaryEnumerator" type="System.Collections.Immutable.Test.ImmutableSortedDictionaryBuilderTest" method="IDictionaryEnumerator" time="0,000" result="Pass" />
+    </collection>
+  </assembly>
+  <assembly name="D:\Dev\corefx\bin\Release\System.Numerics.Vectors.Tests\System.Numerics.Vectors.Tests.dll" environment="32-bit .NET 4.0.30319.34014" test-framework="xUnit.net 1.9.2.1705" run-date="2014-11-15" run-time="17:25:48" total="1039" passed="1039" failed="0" skipped="0" time="2,277" errors="0">
+    <errors />
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2CreateRotationCenterTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2CreateRotationCenterTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringCurrencySByte" type="System.Numerics.Tests.GenericVectorTests" method="ToStringCurrencySByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualAnyUInt16" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualAnyUInt16" time="0,014" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateTranslationTest2" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateTranslationTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.EqualsObjectInt32" type="System.Numerics.Tests.GenericVectorTests" method="EqualsObjectInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateBillboardTest12" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateBillboardTest12" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateConstrainedBillboardTest12" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateConstrainedBillboardTest12" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateConstrainedBillboardAlongAxisTest5" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateConstrainedBillboardAlongAxisTest5" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MaxUInt32" type="System.Numerics.Tests.GenericVectorTests" method="MaxUInt32" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateBillboardTest02" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateBillboardTest02" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4InequalityTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4InequalityTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2AbsTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2AbsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3GetHashCodeTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3GetHashCodeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToWithOffsetReflectionDouble" type="System.Numerics.Tests.GenericVectorTests" method="CopyToWithOffsetReflectionDouble" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualAllByte" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualAllByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4TransformVector2Test2" type="System.Numerics.Tests.Vector4Tests" method="Vector4TransformVector2Test2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanAnyInt32" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanAnyInt32" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4LengthTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4LengthTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseOrOperatorSByte" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseOrOperatorSByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4TransformVector4QuaternionTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4TransformVector4QuaternionTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2CreateSkewXYTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2CreateSkewXYTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.UnaryMinusInt64" type="System.Numerics.Tests.GenericVectorTests" method="UnaryMinusInt64" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionUInt64" type="System.Numerics.Tests.GenericVectorTests" method="AdditionUInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToUInt16" type="System.Numerics.Tests.GenericVectorTests" method="CopyToUInt16" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4UnaryNegationTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4UnaryNegationTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToUInt32" type="System.Numerics.Tests.GenericVectorTests" method="CopyToUInt32" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4IsIdentityTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4IsIdentityTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualAllUInt16" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualAllUInt16" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseAndNotInt64" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseAndNotInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4DivisionTest2" type="System.Numerics.Tests.Vector4Tests" method="Vector4DivisionTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateBillboardTest08" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateBillboardTest08" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorWithOffsetInt64" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorWithOffsetInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanAllUInt32" type="System.Numerics.Tests.GenericVectorTests" method="LessThanAllUInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4InvertIdentityTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4InvertIdentityTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionReflectionUInt16" type="System.Numerics.Tests.GenericVectorTests" method="AdditionReflectionUInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateRotationYTest1" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateRotationYTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4ConstructorTest5" type="System.Numerics.Tests.Vector4Tests" method="Vector4ConstructorTest5" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4MultiplyTest1" type="System.Numerics.Tests.Vector4Tests" method="Vector4MultiplyTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionSubtractTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionSubtractTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionMultiplyTest2" type="System.Numerics.Tests.QuaternionTests" method="QuaternionMultiplyTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4TransformVector2Test1" type="System.Numerics.Tests.Vector4Tests" method="Vector4TransformVector2Test1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MaxUInt16" type="System.Numerics.Tests.GenericVectorTests" method="MaxUInt16" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SubtractionOverflowUInt16" type="System.Numerics.Tests.GenericVectorTests" method="SubtractionOverflowUInt16" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionLerpTest3" type="System.Numerics.Tests.QuaternionTests" method="QuaternionLerpTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2SizeofTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2SizeofTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationReflectionInt32" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationReflectionInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualByte" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionInt32" type="System.Numerics.Tests.GenericVectorTests" method="DivisionInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionConjugateTest1" type="System.Numerics.Tests.QuaternionTests" method="QuaternionConjugateTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3ConstructorTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3ConstructorTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2ClampTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2ClampTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationUInt32" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationUInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4SubtractionTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4SubtractionTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateScaleTest2" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateScaleTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualInt32" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DotProductUInt32" type="System.Numerics.Tests.GenericVectorTests" method="DotProductUInt32" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseOnesComplementOperatorInt16" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseOnesComplementOperatorInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionSingle" type="System.Numerics.Tests.GenericVectorTests" method="DivisionSingle" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToSByte" type="System.Numerics.Tests.GenericVectorTests" method="CopyToSByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3EqualityTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3EqualityTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateRotationXCenterTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateRotationXCenterTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2CreateTranslationTest2" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2CreateTranslationTest2" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorInt64" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualAllByte" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualAllByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionByZeroExceptionInt16" type="System.Numerics.Tests.GenericVectorTests" method="DivisionByZeroExceptionInt16" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateConstrainedBillboardTest02" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateConstrainedBillboardTest02" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4InequalityTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4InequalityTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4LerpTest4" type="System.Numerics.Tests.Vector4Tests" method="Vector4LerpTest4" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AbsInt64" type="System.Numerics.Tests.GenericVectorTests" method="AbsInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionConstructorTest1" type="System.Numerics.Tests.QuaternionTests" method="QuaternionConstructorTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionByte" type="System.Numerics.Tests.GenericVectorTests" method="AdditionByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationInt64" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseOrOperatorUInt32" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseOrOperatorUInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4ConstructorTest2" type="System.Numerics.Tests.Vector4Tests" method="Vector4ConstructorTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SubtractionInt64" type="System.Numerics.Tests.GenericVectorTests" method="SubtractionInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanAllSByte" type="System.Numerics.Tests.GenericVectorTests" method="LessThanAllSByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorWithOffsetInt16" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorWithOffsetInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionReflectionInt32" type="System.Numerics.Tests.GenericVectorTests" method="AdditionReflectionInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateRotationXTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateRotationXTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MinInt64" type="System.Numerics.Tests.GenericVectorTests" method="MinInt64" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionSizeofTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionSizeofTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualSByte" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualSByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorDefaultInt64" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorDefaultInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3TransformNormalTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3TransformNormalTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionDouble" type="System.Numerics.Tests.GenericVectorTests" method="AdditionDouble" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2CreateScaleCenterTest2" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2CreateScaleCenterTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualUInt32" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualUInt32" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanAllUInt64" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanAllUInt64" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorExceptionUInt64" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorExceptionUInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3TransformTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3TransformTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToWithOffsetUInt64" type="System.Numerics.Tests.GenericVectorTests" method="CopyToWithOffsetUInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanUInt32" type="System.Numerics.Tests.GenericVectorTests" method="LessThanUInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.EqualsObjectUInt32" type="System.Numerics.Tests.GenericVectorTests" method="EqualsObjectUInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationWithScalarInt16" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationWithScalarInt16" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionUInt64" type="System.Numerics.Tests.GenericVectorTests" method="DivisionUInt64" time="0,007" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionEqualsTest1" type="System.Numerics.Tests.QuaternionTests" method="QuaternionEqualsTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2CreateScaleCenterTest3" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2CreateScaleCenterTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.UnaryMinusUInt64" type="System.Numerics.Tests.GenericVectorTests" method="UnaryMinusUInt64" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionReflectionSingle" type="System.Numerics.Tests.GenericVectorTests" method="DivisionReflectionSingle" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConditionalSelectUInt64" type="System.Numerics.Tests.GenericVectorTests" method="ConditionalSelectUInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanAnyUInt64" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanAnyUInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionNormalizeTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionNormalizeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2MinTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2MinTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsAllSByte" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsAllSByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToUInt64" type="System.Numerics.Tests.GenericVectorTests" method="CopyToUInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualAllUInt64" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualAllUInt64" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionFromRotationMatrixWithScaledMatrixTest2" type="System.Numerics.Tests.QuaternionTests" method="QuaternionFromRotationMatrixWithScaledMatrixTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanAnyUInt32" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanAnyUInt32" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2DivideTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2DivideTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorDefaultInt32" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorDefaultInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2CreateScaleCenterTest1" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2CreateScaleCenterTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MaxDouble" type="System.Numerics.Tests.GenericVectorTests" method="MaxDouble" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanAnyDouble" type="System.Numerics.Tests.GenericVectorTests" method="LessThanAnyDouble" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4GetHashCodeTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4GetHashCodeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.PlaneTests.PlaneConstructorTest3" type="System.Numerics.Tests.PlaneTests" method="PlaneConstructorTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3NormalizeTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3NormalizeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringExponentialInt64" type="System.Numerics.Tests.GenericVectorTests" method="ToStringExponentialInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsAnyInt32" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsAnyInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsAnyUInt64" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsAnyUInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanUInt16" type="System.Numerics.Tests.GenericVectorTests" method="LessThanUInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsInt64" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4TransformTest1" type="System.Numerics.Tests.Vector4Tests" method="Vector4TransformTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2DivisionTest2" type="System.Numerics.Tests.Vector2Tests" method="Vector2DivisionTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2EqualsTest1" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2EqualsTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4ConstructorTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4ConstructorTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2CreateRotationTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2CreateRotationTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4DotTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4DotTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MaxUInt64" type="System.Numerics.Tests.GenericVectorTests" method="MaxUInt64" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.EqualsVectorInt32" type="System.Numerics.Tests.GenericVectorTests" method="EqualsVectorInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.IndexerOutOfRangeUInt16" type="System.Numerics.Tests.GenericVectorTests" method="IndexerOutOfRangeUInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanAnyInt64" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanAnyInt64" time="0,013" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionIsIdentityTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionIsIdentityTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MaxSByte" type="System.Numerics.Tests.GenericVectorTests" method="MaxSByte" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AbsInt16" type="System.Numerics.Tests.GenericVectorTests" method="AbsInt16" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DotProductInt32" type="System.Numerics.Tests.GenericVectorTests" method="DotProductInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualAnySingle" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualAnySingle" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3DivisionTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3DivisionTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorWithOffsetByte" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorWithOffsetByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3ConstructorTest3" type="System.Numerics.Tests.Vector3Tests" method="Vector3ConstructorTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionCreateFromAxisAngleTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionCreateFromAxisAngleTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateTranslationTest1" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateTranslationTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MinSingle" type="System.Numerics.Tests.GenericVectorTests" method="MinSingle" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionCreateFromYawPitchRollTest2" type="System.Numerics.Tests.QuaternionTests" method="QuaternionCreateFromYawPitchRollTest2" time="0,105" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseAndOperatorInt32" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseAndOperatorInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.IndexerOutOfRangeByte" type="System.Numerics.Tests.GenericVectorTests" method="IndexerOutOfRangeByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationReflectionUInt64" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationReflectionUInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToReflectionInt64" type="System.Numerics.Tests.GenericVectorTests" method="CopyToReflectionInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4NormalizeTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4NormalizeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionSByte" type="System.Numerics.Tests.GenericVectorTests" method="DivisionSByte" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsSByte" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsSByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4DivisionTest3" type="System.Numerics.Tests.Vector4Tests" method="Vector4DivisionTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionByZeroExceptionUInt16" type="System.Numerics.Tests.GenericVectorTests" method="DivisionByZeroExceptionUInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringGeneralUInt32" type="System.Numerics.Tests.GenericVectorTests" method="ToStringGeneralUInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.SetFieldsTest" type="System.Numerics.Tests.Vector3Tests" method="SetFieldsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.IndexerOutOfRangeSingle" type="System.Numerics.Tests.GenericVectorTests" method="IndexerOutOfRangeSingle" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringCurrencyDouble" type="System.Numerics.Tests.GenericVectorTests" method="ToStringCurrencyDouble" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateConstrainedBillboardTest04" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateConstrainedBillboardTest04" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreatePerspectiveFieldOfViewTest5" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreatePerspectiveFieldOfViewTest5" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3DivisionTest2" type="System.Numerics.Tests.Vector3Tests" method="Vector3DivisionTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3NormalizeTest1" type="System.Numerics.Tests.Vector3Tests" method="Vector3NormalizeTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualAnySByte" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualAnySByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionCreateFromAxisAngleTest2" type="System.Numerics.Tests.QuaternionTests" method="QuaternionCreateFromAxisAngleTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorConstantValueSByte" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorConstantValueSByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AbsInt32" type="System.Numerics.Tests.GenericVectorTests" method="AbsInt32" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4TransformVector2QuaternionTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4TransformVector2QuaternionTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GetHashCodeUInt32" type="System.Numerics.Tests.GenericVectorTests" method="GetHashCodeUInt32" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreatePerspectiveFieldOfViewTest4" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreatePerspectiveFieldOfViewTest4" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionSingle" type="System.Numerics.Tests.GenericVectorTests" method="AdditionSingle" time="0,006" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorSingle" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorSingle" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4DecomposeTest03" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4DecomposeTest03" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4NormalizeTest1" type="System.Numerics.Tests.Vector4Tests" method="Vector4NormalizeTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsByte" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3ReflectTest1" type="System.Numerics.Tests.Vector3Tests" method="Vector3ReflectTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsSingle" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsSingle" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionReflectionByte" type="System.Numerics.Tests.GenericVectorTests" method="AdditionReflectionByte" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorWithOffsetSByte" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorWithOffsetSByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsAllSingle" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsAllSingle" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4TransformVector4Test2" type="System.Numerics.Tests.Vector4Tests" method="Vector4TransformVector4Test2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DotProductUInt64" type="System.Numerics.Tests.GenericVectorTests" method="DotProductUInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseOrOperatorUInt64" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseOrOperatorUInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2ToStringTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2ToStringTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorDefaultUInt16" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorDefaultUInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SquareRootDouble" type="System.Numerics.Tests.GenericVectorTests" method="SquareRootDouble" time="0,010" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4FromQuaternionTest4" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4FromQuaternionTest4" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3AdditionTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3AdditionTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualSByte" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualSByte" time="0,010" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4CopyToTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4CopyToTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2InvertIdentityTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2InvertIdentityTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualInt32" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorExceptionByte" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorExceptionByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsAnyUInt16" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsAnyUInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateScaleTest1" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateScaleTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionUInt16" type="System.Numerics.Tests.GenericVectorTests" method="AdditionUInt16" time="0,006" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2LerpTest4" type="System.Numerics.Tests.Vector2Tests" method="Vector2LerpTest4" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToReflectionInt32" type="System.Numerics.Tests.GenericVectorTests" method="CopyToReflectionInt32" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionUnaryNegationTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionUnaryNegationTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionSlerpTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionSlerpTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3DotTest1" type="System.Numerics.Tests.Vector3Tests" method="Vector3DotTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanAllUInt16" type="System.Numerics.Tests.GenericVectorTests" method="LessThanAllUInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4EqualsTest1" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4EqualsTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanAnySByte" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanAnySByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3LengthTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3LengthTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3ConstructorTest1" type="System.Numerics.Tests.Vector3Tests" method="Vector3ConstructorTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionFromRotationMatrixTest5" type="System.Numerics.Tests.QuaternionTests" method="QuaternionFromRotationMatrixTest5" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.PlaneTests.PlaneDotTest" type="System.Numerics.Tests.PlaneTests" method="PlaneDotTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.PlaneTests.PlaneDotNormalTest" type="System.Numerics.Tests.PlaneTests" method="PlaneDotNormalTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.EmbeddedVectorSetFields" type="System.Numerics.Tests.Vector3Tests" method="EmbeddedVectorSetFields" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualAllUInt32" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualAllUInt32" time="0,011" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseOrOperatorInt64" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseOrOperatorInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseAndOperatorSingle" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseAndOperatorSingle" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3DotTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3DotTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseXorOperatorInt16" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseXorOperatorInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanAllUInt64" type="System.Numerics.Tests.GenericVectorTests" method="LessThanAllUInt64" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.DeeplyEmbeddedObjectTest" type="System.Numerics.Tests.Vector4Tests" method="DeeplyEmbeddedObjectTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationWithScalarUInt64" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationWithScalarUInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsAnySingle" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsAnySingle" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanInt16" type="System.Numerics.Tests.GenericVectorTests" method="LessThanInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2CreateScaleTest1" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2CreateScaleTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3LerpTest2" type="System.Numerics.Tests.Vector3Tests" method="Vector3LerpTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.IndexerOutOfRangeInt64" type="System.Numerics.Tests.GenericVectorTests" method="IndexerOutOfRangeInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4ToStringTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4ToStringTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2DotTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2DotTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationReflectionDouble" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationReflectionDouble" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionAdditionTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionAdditionTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.PlaneTests.PlaneEqualityTest" type="System.Numerics.Tests.PlaneTests" method="PlaneEqualityTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4TransformVector3Test1" type="System.Numerics.Tests.Vector4Tests" method="Vector4TransformVector3Test1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToInt32" type="System.Numerics.Tests.GenericVectorTests" method="CopyToInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SubtractionOverflowUInt64" type="System.Numerics.Tests.GenericVectorTests" method="SubtractionOverflowUInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionSlerpTest1" type="System.Numerics.Tests.QuaternionTests" method="QuaternionSlerpTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.SetFieldsTest" type="System.Numerics.Tests.Vector4Tests" method="SetFieldsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4DotTest1" type="System.Numerics.Tests.Vector4Tests" method="Vector4DotTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2MaxTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2MaxTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanAllInt16" type="System.Numerics.Tests.GenericVectorTests" method="LessThanAllInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SquareRootInt32" type="System.Numerics.Tests.GenericVectorTests" method="SquareRootInt32" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4DivideTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4DivideTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreatePerspectiveTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreatePerspectiveTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.EqualsVectorUInt16" type="System.Numerics.Tests.GenericVectorTests" method="EqualsVectorUInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2UnaryNegationTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2UnaryNegationTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.PlaneTests.PlaneEqualsTest1" type="System.Numerics.Tests.PlaneTests" method="PlaneEqualsTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConditionalSelectSingle" type="System.Numerics.Tests.GenericVectorTests" method="ConditionalSelectSingle" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionUInt32" type="System.Numerics.Tests.GenericVectorTests" method="DivisionUInt32" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringGeneralUInt16" type="System.Numerics.Tests.GenericVectorTests" method="ToStringGeneralUInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4InvertAffineTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4InvertAffineTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SquareRootUInt32" type="System.Numerics.Tests.GenericVectorTests" method="SquareRootUInt32" time="0,071" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringExponentialInt32" type="System.Numerics.Tests.GenericVectorTests" method="ToStringExponentialInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.EqualsObjectInt16" type="System.Numerics.Tests.GenericVectorTests" method="EqualsObjectInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorArrayReflectionSingle" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorArrayReflectionSingle" time="0,392" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2NegateTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2NegateTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3DistanceTest1" type="System.Numerics.Tests.Vector3Tests" method="Vector3DistanceTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.PlaneTests.PlaneDotCoordinateTest" type="System.Numerics.Tests.PlaneTests" method="PlaneDotCoordinateTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualAllSByte" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualAllSByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.IndexerOutOfRangeUInt64" type="System.Numerics.Tests.GenericVectorTests" method="IndexerOutOfRangeUInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringExponentialSingle" type="System.Numerics.Tests.GenericVectorTests" method="ToStringExponentialSingle" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationReflectionUInt16" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationReflectionUInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorConstantValueUInt32" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorConstantValueUInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4DeterminantTest1" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4DeterminantTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateScaleTest3" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateScaleTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanDouble" type="System.Numerics.Tests.GenericVectorTests" method="LessThanDouble" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationWithScalarUInt32" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationWithScalarUInt32" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionReflectionSByte" type="System.Numerics.Tests.GenericVectorTests" method="DivisionReflectionSByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualAnySByte" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualAnySByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualUInt64" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualUInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GetHashCodeUInt64" type="System.Numerics.Tests.GenericVectorTests" method="GetHashCodeUInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.PlaneTests.PlaneTransformTest1" type="System.Numerics.Tests.PlaneTests" method="PlaneTransformTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateRotationZCenterTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateRotationZCenterTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4DivisionTest1" type="System.Numerics.Tests.Vector4Tests" method="Vector4DivisionTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2LerpTest2" type="System.Numerics.Tests.Vector2Tests" method="Vector2LerpTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorGreaterThanSingle" type="System.Numerics.Tests.GenericVectorTests" method="VectorGreaterThanSingle" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToWithOffsetReflectionInt16" type="System.Numerics.Tests.GenericVectorTests" method="CopyToWithOffsetReflectionInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4MultiplyTest5" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4MultiplyTest5" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4EqualsNanTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4EqualsNanTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorExceptionSingle" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorExceptionSingle" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4TransformVector3QuaternionTest2" type="System.Numerics.Tests.Vector4Tests" method="Vector4TransformVector3QuaternionTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualAllInt64" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualAllInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualAllUInt32" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualAllUInt32" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3MarshalSizeTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3MarshalSizeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualAnyInt64" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualAnyInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3DivisionTest1" type="System.Numerics.Tests.Vector3Tests" method="Vector3DivisionTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseXorOperatorInt64" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseXorOperatorInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SubtractionOverflowUInt32" type="System.Numerics.Tests.GenericVectorTests" method="SubtractionOverflowUInt32" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualAnyUInt64" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualAnyUInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanAllDouble" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanAllDouble" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.PlaneTests.PlaneConstructorTest" type="System.Numerics.Tests.PlaneTests" method="PlaneConstructorTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionReflectionByte" type="System.Numerics.Tests.GenericVectorTests" method="DivisionReflectionByte" time="0,007" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2ToStringTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2ToStringTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GetHashCodeDouble" type="System.Numerics.Tests.GenericVectorTests" method="GetHashCodeDouble" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringGeneralInt64" type="System.Numerics.Tests.GenericVectorTests" method="ToStringGeneralInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2UnaryNegationTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2UnaryNegationTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4TransformVector2QuaternionTest2" type="System.Numerics.Tests.Vector4Tests" method="Vector4TransformVector2QuaternionTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionSubtractionTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionSubtractionTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3UnitZTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3UnitZTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4EqualityTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4EqualityTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.EqualsVectorInt16" type="System.Numerics.Tests.GenericVectorTests" method="EqualsVectorInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateConstrainedBillboardAlongAxisTest4" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateConstrainedBillboardAlongAxisTest4" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseAndOperatorDouble" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseAndOperatorDouble" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToReflectionInt16" type="System.Numerics.Tests.GenericVectorTests" method="CopyToReflectionInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2IsIdentityTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2IsIdentityTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2MultiplyTest4" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2MultiplyTest4" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorConstantValueUInt64" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorConstantValueUInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToWithOffsetReflectionByte" type="System.Numerics.Tests.GenericVectorTests" method="CopyToWithOffsetReflectionByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringGeneralInt16" type="System.Numerics.Tests.GenericVectorTests" method="ToStringGeneralInt16" time="0,016" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateReflectionTest01" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateReflectionTest01" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsUInt64" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsUInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationReflectionByte" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationReflectionByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorConstantValueDouble" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorConstantValueDouble" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3SubtractionTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3SubtractionTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.StaticZeroVectorDouble" type="System.Numerics.Tests.GenericVectorTests" method="StaticZeroVectorDouble" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanByte" type="System.Numerics.Tests.GenericVectorTests" method="LessThanByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseAndNotUInt16" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseAndNotUInt16" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsUInt32" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsUInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorSingleValueReflectionDouble" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorSingleValueReflectionDouble" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConditionalSelectByte" type="System.Numerics.Tests.GenericVectorTests" method="ConditionalSelectByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsAllByte" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsAllByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsAnySByte" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsAnySByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2CreateScaleTest3" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2CreateScaleTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.IndexerOutOfRangeDouble" type="System.Numerics.Tests.GenericVectorTests" method="IndexerOutOfRangeDouble" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualAnySingle" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualAnySingle" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.StaticZeroVectorSingle" type="System.Numerics.Tests.GenericVectorTests" method="StaticZeroVectorSingle" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4FromQuaternionTest2" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4FromQuaternionTest2" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.StaticZeroVectorInt32" type="System.Numerics.Tests.GenericVectorTests" method="StaticZeroVectorInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorUInt16" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorUInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateBillboardTest10" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateBillboardTest10" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.EmbeddedVectorSetFields" type="System.Numerics.Tests.Vector4Tests" method="EmbeddedVectorSetFields" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorArrayReflectionDouble" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorArrayReflectionDouble" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4EqualsTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4EqualsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4TransformVector4Test1" type="System.Numerics.Tests.Vector4Tests" method="Vector4TransformVector4Test1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationWithScalarUInt16" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationWithScalarUInt16" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionDotTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionDotTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.StaticOneVectorUInt32" type="System.Numerics.Tests.GenericVectorTests" method="StaticOneVectorUInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4DistanceSquaredTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4DistanceSquaredTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionByZeroExceptionInt64" type="System.Numerics.Tests.GenericVectorTests" method="DivisionByZeroExceptionInt64" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConditionalSelectDouble" type="System.Numerics.Tests.GenericVectorTests" method="ConditionalSelectDouble" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateBillboardTest07" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateBillboardTest07" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2LerpTest3" type="System.Numerics.Tests.Vector2Tests" method="Vector2LerpTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4LengthSquaredTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4LengthSquaredTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToWithOffsetSByte" type="System.Numerics.Tests.GenericVectorTests" method="CopyToWithOffsetSByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4InvertTranslationTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4InvertTranslationTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToWithOffsetReflectionInt32" type="System.Numerics.Tests.GenericVectorTests" method="CopyToWithOffsetReflectionInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4FromQuaternionTest3" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4FromQuaternionTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3LerpTest3" type="System.Numerics.Tests.Vector3Tests" method="Vector3LerpTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorConstantValueInt32" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorConstantValueInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionSByte" type="System.Numerics.Tests.GenericVectorTests" method="AdditionSByte" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseAndOperatorUInt16" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseAndOperatorUInt16" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4TransformVector2QuaternionTest1" type="System.Numerics.Tests.Vector4Tests" method="Vector4TransformVector2QuaternionTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToWithOffsetInt16" type="System.Numerics.Tests.GenericVectorTests" method="CopyToWithOffsetInt16" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3MaxTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3MaxTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseAndNotUInt64" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseAndNotUInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateScaleCenterTest1" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateScaleCenterTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3UnitXTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3UnitXTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GetHashCodeSingle" type="System.Numerics.Tests.GenericVectorTests" method="GetHashCodeSingle" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsDouble" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsDouble" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseAndOperatorInt64" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseAndOperatorInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3LerpTest5" type="System.Numerics.Tests.Vector3Tests" method="Vector3LerpTest5" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2LerpTest6" type="System.Numerics.Tests.Vector2Tests" method="Vector2LerpTest6" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionInt16" type="System.Numerics.Tests.GenericVectorTests" method="DivisionInt16" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4UnitYTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4UnitYTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionSlerpTest3" type="System.Numerics.Tests.QuaternionTests" method="QuaternionSlerpTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringGeneralInt32" type="System.Numerics.Tests.GenericVectorTests" method="ToStringGeneralInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionConcatenateTest1" type="System.Numerics.Tests.QuaternionTests" method="QuaternionConcatenateTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorDefaultUInt64" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorDefaultUInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorExceptionSByte" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorExceptionSByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateRotationXTest1" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateRotationXTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AbsSingle" type="System.Numerics.Tests.GenericVectorTests" method="AbsSingle" time="0,007" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreatePerspectiveTest2" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreatePerspectiveTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2MultiplyTest5" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2MultiplyTest5" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2EqualsTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2EqualsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseOrOperatorInt16" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseOrOperatorInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsUInt16" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsUInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.StaticOneVectorUInt64" type="System.Numerics.Tests.GenericVectorTests" method="StaticOneVectorUInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanAllByte" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanAllByte" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2EqualsNanTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2EqualsNanTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.PlaneTests.PlaneInequalityTest" type="System.Numerics.Tests.PlaneTests" method="PlaneInequalityTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateRotationYCenterTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateRotationYCenterTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4DistanceTest1" type="System.Numerics.Tests.Vector4Tests" method="Vector4DistanceTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AbsUInt64" type="System.Numerics.Tests.GenericVectorTests" method="AbsUInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsAllDouble" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsAllDouble" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2CreateSkewXTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2CreateSkewXTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4LerpTest2" type="System.Numerics.Tests.Vector4Tests" method="Vector4LerpTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.EqualsObjectUInt64" type="System.Numerics.Tests.GenericVectorTests" method="EqualsObjectUInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorSingleValueReflectionUInt32" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorSingleValueReflectionUInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DotProductDouble" type="System.Numerics.Tests.GenericVectorTests" method="DotProductDouble" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanUInt64" type="System.Numerics.Tests.GenericVectorTests" method="LessThanUInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4ConstructorTest1" type="System.Numerics.Tests.Vector4Tests" method="Vector4ConstructorTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualAllSingle" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualAllSingle" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseAndOperatorSByte" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseAndOperatorSByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseAndOperatorInt16" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseAndOperatorInt16" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateConstrainedBillboardAlongAxisTest1" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateConstrainedBillboardAlongAxisTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2ReflectTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2ReflectTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseOnesComplementOperatorSByte" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseOnesComplementOperatorSByte" time="0,013" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3MinMaxCodeCoverageTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3MinMaxCodeCoverageTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3MultiplyTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3MultiplyTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorArrayReflectionByte" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorArrayReflectionByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionUInt32" type="System.Numerics.Tests.GenericVectorTests" method="AdditionUInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionFromRotationMatrixTest1" type="System.Numerics.Tests.QuaternionTests" method="QuaternionFromRotationMatrixTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4TransformVector2Test" type="System.Numerics.Tests.Vector4Tests" method="Vector4TransformVector2Test" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualSingle" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualSingle" time="0,007" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.StaticOneVectorInt64" type="System.Numerics.Tests.GenericVectorTests" method="StaticOneVectorInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualAnyUInt64" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualAnyUInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionFromRotationMatrixTest4" type="System.Numerics.Tests.QuaternionTests" method="QuaternionFromRotationMatrixTest4" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2MultiplyTest1" type="System.Numerics.Tests.Vector2Tests" method="Vector2MultiplyTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SubtractionOverflowInt32" type="System.Numerics.Tests.GenericVectorTests" method="SubtractionOverflowInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToReflectionByte" type="System.Numerics.Tests.GenericVectorTests" method="CopyToReflectionByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.PlaneTests.PlaneConstructorTest1" type="System.Numerics.Tests.PlaneTests" method="PlaneConstructorTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateConstrainedBillboardTest03" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateConstrainedBillboardTest03" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorSingleValueReflectionInt32" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorSingleValueReflectionInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AbsUInt32" type="System.Numerics.Tests.GenericVectorTests" method="AbsUInt32" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.UnaryMinusUInt16" type="System.Numerics.Tests.GenericVectorTests" method="UnaryMinusUInt16" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SubtractionInt16" type="System.Numerics.Tests.GenericVectorTests" method="SubtractionInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToWithOffsetReflectionSByte" type="System.Numerics.Tests.GenericVectorTests" method="CopyToWithOffsetReflectionSByte" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionInverseTest1" type="System.Numerics.Tests.QuaternionTests" method="QuaternionInverseTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3ReflectTest3" type="System.Numerics.Tests.Vector3Tests" method="Vector3ReflectTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationWithScalarInt64" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationWithScalarInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToReflectionDouble" type="System.Numerics.Tests.GenericVectorTests" method="CopyToReflectionDouble" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateBillboardTest01" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateBillboardTest01" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConditionalSelectInt16" type="System.Numerics.Tests.GenericVectorTests" method="ConditionalSelectInt16" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToWithOffsetInt64" type="System.Numerics.Tests.GenericVectorTests" method="CopyToWithOffsetInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2MultiplyTest3" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2MultiplyTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateShadowTest02" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateShadowTest02" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualAllSingle" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualAllSingle" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsAnyUInt32" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsAnyUInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.SetFieldsTest" type="System.Numerics.Tests.Vector2Tests" method="SetFieldsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualInt16" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualInt16" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionReflectionInt32" type="System.Numerics.Tests.GenericVectorTests" method="DivisionReflectionInt32" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionInt16" type="System.Numerics.Tests.GenericVectorTests" method="AdditionInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToByte" type="System.Numerics.Tests.GenericVectorTests" method="CopyToByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringExponentialInt16" type="System.Numerics.Tests.GenericVectorTests" method="ToStringExponentialInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionEqualityTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionEqualityTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionLengthSquaredTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionLengthSquaredTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualAllInt16" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualAllInt16" time="0,008" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateConstrainedBillboardTest06" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateConstrainedBillboardTest06" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.StaticZeroVectorUInt64" type="System.Numerics.Tests.GenericVectorTests" method="StaticZeroVectorUInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorSingleValueReflectionUInt16" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorSingleValueReflectionUInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3TransformByQuaternionTest2" type="System.Numerics.Tests.Vector3Tests" method="Vector3TransformByQuaternionTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2MultiplyTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2MultiplyTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualAnyInt16" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualAnyInt16" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringCurrencyInt32" type="System.Numerics.Tests.GenericVectorTests" method="ToStringCurrencyInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualByte" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualByte" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MinByte" type="System.Numerics.Tests.GenericVectorTests" method="MinByte" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionLerpTest2" type="System.Numerics.Tests.QuaternionTests" method="QuaternionLerpTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringExponentialByte" type="System.Numerics.Tests.GenericVectorTests" method="ToStringExponentialByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.EmbeddedVectorSetFields" type="System.Numerics.Tests.Vector2Tests" method="EmbeddedVectorSetFields" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateBillboardTest04" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateBillboardTest04" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SubtractionUInt16" type="System.Numerics.Tests.GenericVectorTests" method="SubtractionUInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateBillboardTooCloseTest1" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateBillboardTooCloseTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SubtractionDouble" type="System.Numerics.Tests.GenericVectorTests" method="SubtractionDouble" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualAllInt64" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualAllInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorExceptionUInt16" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorExceptionUInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorGreaterThanUInt32" type="System.Numerics.Tests.GenericVectorTests" method="VectorGreaterThanUInt32" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseOnesComplementOperatorByte" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseOnesComplementOperatorByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionReflectionInt64" type="System.Numerics.Tests.GenericVectorTests" method="DivisionReflectionInt64" time="0,006" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.StaticZeroVectorUInt16" type="System.Numerics.Tests.GenericVectorTests" method="StaticZeroVectorUInt16" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualAnyInt16" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualAnyInt16" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorInt16" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2MultiplyTest1" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2MultiplyTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DotProductByte" type="System.Numerics.Tests.GenericVectorTests" method="DotProductByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2InvertTranslationTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2InvertTranslationTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SquareRootUInt16" type="System.Numerics.Tests.GenericVectorTests" method="SquareRootUInt16" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionConstructorTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionConstructorTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MinUInt16" type="System.Numerics.Tests.GenericVectorTests" method="MinUInt16" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorByte" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionAddTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionAddTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanAnyInt64" type="System.Numerics.Tests.GenericVectorTests" method="LessThanAnyInt64" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringCurrencyUInt32" type="System.Numerics.Tests.GenericVectorTests" method="ToStringCurrencyUInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AbsSByte" type="System.Numerics.Tests.GenericVectorTests" method="AbsSByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3AddTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3AddTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2ConstructorTest3" type="System.Numerics.Tests.Vector2Tests" method="Vector2ConstructorTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4TransformVector4Test" type="System.Numerics.Tests.Vector4Tests" method="Vector4TransformVector4Test" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2SubtractionTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2SubtractionTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToReflectionUInt32" type="System.Numerics.Tests.GenericVectorTests" method="CopyToReflectionUInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.StaticZeroVectorInt16" type="System.Numerics.Tests.GenericVectorTests" method="StaticZeroVectorInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsInt32" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanInt64" type="System.Numerics.Tests.GenericVectorTests" method="LessThanInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseAndOperatorByte" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseAndOperatorByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3DivideTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3DivideTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringGeneralSByte" type="System.Numerics.Tests.GenericVectorTests" method="ToStringGeneralSByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationUInt64" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationUInt64" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionMultiplyTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionMultiplyTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4AbsTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4AbsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4MultiplyTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4MultiplyTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualSingle" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualSingle" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateConstrainedBillboardTest01" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateConstrainedBillboardTest01" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2AdditionTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2AdditionTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionReflectionUInt64" type="System.Numerics.Tests.GenericVectorTests" method="DivisionReflectionUInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateConstrainedBillboardTest09" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateConstrainedBillboardTest09" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GetHashCodeInt16" type="System.Numerics.Tests.GenericVectorTests" method="GetHashCodeInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorDefaultDouble" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorDefaultDouble" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DotProductInt64" type="System.Numerics.Tests.GenericVectorTests" method="DotProductInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationReflectionInt64" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationReflectionInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3ZeroTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3ZeroTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2SubtractTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2SubtractTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualAllSByte" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualAllSByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2LengthTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2LengthTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SubtractionOverflowInt16" type="System.Numerics.Tests.GenericVectorTests" method="SubtractionOverflowInt16" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseAndOperatorUInt32" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseAndOperatorUInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3LengthSquaredTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3LengthSquaredTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToWithOffsetDouble" type="System.Numerics.Tests.GenericVectorTests" method="CopyToWithOffsetDouble" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorWithOffsetUInt16" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorWithOffsetUInt16" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorConstantValueByte" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorConstantValueByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4EqualsTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4EqualsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3UnitYTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3UnitYTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorSingleValueReflectionByte" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorSingleValueReflectionByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionOverflowUInt64" type="System.Numerics.Tests.GenericVectorTests" method="AdditionOverflowUInt64" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionCreateFromYawPitchRollTest1" type="System.Numerics.Tests.QuaternionTests" method="QuaternionCreateFromYawPitchRollTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.EqualsVectorDouble" type="System.Numerics.Tests.GenericVectorTests" method="EqualsVectorDouble" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateRotationZTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateRotationZTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3CrossTest1" type="System.Numerics.Tests.Vector3Tests" method="Vector3CrossTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DotProductUInt16" type="System.Numerics.Tests.GenericVectorTests" method="DotProductUInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MinUInt32" type="System.Numerics.Tests.GenericVectorTests" method="MinUInt32" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4DecomposeTest02" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4DecomposeTest02" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanAllByte" type="System.Numerics.Tests.GenericVectorTests" method="LessThanAllByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionOverflowInt64" type="System.Numerics.Tests.GenericVectorTests" method="AdditionOverflowInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateShadowTest01" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateShadowTest01" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToWithOffsetReflectionUInt16" type="System.Numerics.Tests.GenericVectorTests" method="CopyToWithOffsetReflectionUInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionDivideTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionDivideTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualUInt16" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualUInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4MinMaxCodeCoverageTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4MinMaxCodeCoverageTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.EqualsObjectDouble" type="System.Numerics.Tests.GenericVectorTests" method="EqualsObjectDouble" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.PlaneTests.PlaneEqualsNanTest" type="System.Numerics.Tests.PlaneTests" method="PlaneEqualsNanTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseXorOperatorByte" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseXorOperatorByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.StaticZeroVectorByte" type="System.Numerics.Tests.GenericVectorTests" method="StaticZeroVectorByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateWorldTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateWorldTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConditionalSelectUInt16" type="System.Numerics.Tests.GenericVectorTests" method="ConditionalSelectUInt16" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionByZeroExceptionInt32" type="System.Numerics.Tests.GenericVectorTests" method="DivisionByZeroExceptionInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2EqualsTest1" type="System.Numerics.Tests.Vector2Tests" method="Vector2EqualsTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateConstrainedBillboardAlongAxisTest2" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateConstrainedBillboardAlongAxisTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorWithOffsetUInt64" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorWithOffsetUInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.StaticOneVectorInt16" type="System.Numerics.Tests.GenericVectorTests" method="StaticOneVectorInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SubtractionOverflowSByte" type="System.Numerics.Tests.GenericVectorTests" method="SubtractionOverflowSByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4FromQuaternionTest1" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4FromQuaternionTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2CreateSkewIdentityTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2CreateSkewIdentityTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2CreateTranslationTest1" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2CreateTranslationTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2UnaryNegationTest2" type="System.Numerics.Tests.Vector2Tests" method="Vector2UnaryNegationTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToInt64" type="System.Numerics.Tests.GenericVectorTests" method="CopyToInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionDouble" type="System.Numerics.Tests.GenericVectorTests" method="DivisionDouble" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorGreaterThanInt16" type="System.Numerics.Tests.GenericVectorTests" method="VectorGreaterThanInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationWithScalarDouble" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationWithScalarDouble" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.EqualsObjectSByte" type="System.Numerics.Tests.GenericVectorTests" method="EqualsObjectSByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionNegateTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionNegateTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4InvertProjectionTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4InvertProjectionTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorArrayReflectionSByte" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorArrayReflectionSByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualAnyUInt32" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualAnyUInt32" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SquareRootInt64" type="System.Numerics.Tests.GenericVectorTests" method="SquareRootInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorExceptionInt16" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorExceptionInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2NormalizeTest2" type="System.Numerics.Tests.Vector2Tests" method="Vector2NormalizeTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualDouble" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualDouble" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.UnaryMinusInt32" type="System.Numerics.Tests.GenericVectorTests" method="UnaryMinusInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4DistanceTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4DistanceTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4AddTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4AddTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4ConstructorTest6" type="System.Numerics.Tests.Vector4Tests" method="Vector4ConstructorTest6" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3LerpTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3LerpTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3EqualsTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3EqualsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualAllInt16" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualAllInt16" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionCreateFromAxisAngleTest1" type="System.Numerics.Tests.QuaternionTests" method="QuaternionCreateFromAxisAngleTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsAllInt16" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsAllInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationInt16" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateBillboardTest05" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateBillboardTest05" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2NegateTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2NegateTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateConstrainedBillboardTooCloseTest1" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateConstrainedBillboardTooCloseTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringGeneralByte" type="System.Numerics.Tests.GenericVectorTests" method="ToStringGeneralByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2MultiplyTest2" type="System.Numerics.Tests.Vector2Tests" method="Vector2MultiplyTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GetHashCodeInt64" type="System.Numerics.Tests.GenericVectorTests" method="GetHashCodeInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4TransformTest2" type="System.Numerics.Tests.Vector4Tests" method="Vector4TransformTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToWithOffsetReflectionSingle" type="System.Numerics.Tests.GenericVectorTests" method="CopyToWithOffsetReflectionSingle" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4ConstructorTest4" type="System.Numerics.Tests.Vector4Tests" method="Vector4ConstructorTest4" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanInt32" type="System.Numerics.Tests.GenericVectorTests" method="LessThanInt32" time="0,006" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4NegateTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4NegateTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4TransformVector3Test" type="System.Numerics.Tests.Vector4Tests" method="Vector4TransformVector3Test" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2LengthSquaredTest1" type="System.Numerics.Tests.Vector2Tests" method="Vector2LengthSquaredTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorGreaterThanUInt16" type="System.Numerics.Tests.GenericVectorTests" method="VectorGreaterThanUInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionFromRotationMatrixTest2" type="System.Numerics.Tests.QuaternionTests" method="QuaternionFromRotationMatrixTest2" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionInt64" type="System.Numerics.Tests.GenericVectorTests" method="DivisionInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateScaleCenterTest2" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateScaleCenterTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanAnyUInt64" type="System.Numerics.Tests.GenericVectorTests" method="LessThanAnyUInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationInt32" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationInt32" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorConstantValueInt64" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorConstantValueInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsAllInt64" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsAllInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsInt16" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanAllInt32" type="System.Numerics.Tests.GenericVectorTests" method="LessThanAllInt32" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorGreaterThanDouble" type="System.Numerics.Tests.GenericVectorTests" method="VectorGreaterThanDouble" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.StaticOneVectorInt32" type="System.Numerics.Tests.GenericVectorTests" method="StaticOneVectorInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorUInt64" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorUInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.StaticZeroVectorInt64" type="System.Numerics.Tests.GenericVectorTests" method="StaticZeroVectorInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseOnesComplementOperatorInt64" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseOnesComplementOperatorInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsAllUInt16" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsAllUInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualAllUInt16" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualAllUInt16" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualAnyDouble" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualAnyDouble" time="0,008" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseXorOperatorUInt16" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseXorOperatorUInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.PlaneTests.PlaneNormalizeTest" type="System.Numerics.Tests.PlaneTests" method="PlaneNormalizeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MinDouble" type="System.Numerics.Tests.GenericVectorTests" method="MinDouble" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionOverflowByte" type="System.Numerics.Tests.GenericVectorTests" method="AdditionOverflowByte" time="0,015" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorArrayReflectionUInt64" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorArrayReflectionUInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3SizeofTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3SizeofTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4TransposeTest1" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4TransposeTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToDouble" type="System.Numerics.Tests.GenericVectorTests" method="CopyToDouble" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.UnaryMinusDouble" type="System.Numerics.Tests.GenericVectorTests" method="UnaryMinusDouble" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2ReflectTest1" type="System.Numerics.Tests.Vector2Tests" method="Vector2ReflectTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3SqrtTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3SqrtTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualAnyByte" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualAnyByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateConstrainedBillboardTest08" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateConstrainedBillboardTest08" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2IdentityTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2IdentityTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionByte" type="System.Numerics.Tests.GenericVectorTests" method="DivisionByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SubtractionInt32" type="System.Numerics.Tests.GenericVectorTests" method="SubtractionInt32" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreatePerspectiveOffCenterTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreatePerspectiveOffCenterTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreatePerspectiveTest3" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreatePerspectiveTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.UnaryMinusUInt32" type="System.Numerics.Tests.GenericVectorTests" method="UnaryMinusUInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SubtractionSingle" type="System.Numerics.Tests.GenericVectorTests" method="SubtractionSingle" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualAnyDouble" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualAnyDouble" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2DivideTest1" type="System.Numerics.Tests.Vector2Tests" method="Vector2DivideTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.EqualsObjectUInt16" type="System.Numerics.Tests.GenericVectorTests" method="EqualsObjectUInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreatePerspectiveFieldOfViewTest1" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreatePerspectiveFieldOfViewTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationReflectionSByte" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationReflectionSByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorExceptionInt32" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorExceptionInt32" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionReflectionUInt32" type="System.Numerics.Tests.GenericVectorTests" method="AdditionReflectionUInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2DeterminantTest1" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2DeterminantTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToWithOffsetInt32" type="System.Numerics.Tests.GenericVectorTests" method="CopyToWithOffsetInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseAndNotInt32" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseAndNotInt32" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3ConstructorTest4" type="System.Numerics.Tests.Vector3Tests" method="Vector3ConstructorTest4" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4InvertTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4InvertTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionOverflowUInt16" type="System.Numerics.Tests.GenericVectorTests" method="AdditionOverflowUInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AbsUInt16" type="System.Numerics.Tests.GenericVectorTests" method="AbsUInt16" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SquareRootByte" type="System.Numerics.Tests.GenericVectorTests" method="SquareRootByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorDefaultByte" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorDefaultByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationReflectionUInt32" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationReflectionUInt32" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringExponentialUInt64" type="System.Numerics.Tests.GenericVectorTests" method="ToStringExponentialUInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4InvertScaleTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4InvertScaleTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4SizeofTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4SizeofTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateRotationYTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateRotationYTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2EqualsTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2EqualsTest" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.EqualsVectorUInt32" type="System.Numerics.Tests.GenericVectorTests" method="EqualsVectorUInt32" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreatePerspectiveOffCenterTest2" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreatePerspectiveOffCenterTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4TransformVector3QuaternionTest1" type="System.Numerics.Tests.Vector4Tests" method="Vector4TransformVector3QuaternionTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SquareRootInt16" type="System.Numerics.Tests.GenericVectorTests" method="SquareRootInt16" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualAnyInt32" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualAnyInt32" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2SubtractionTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2SubtractionTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4MaxTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4MaxTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2ConstructorTest4" type="System.Numerics.Tests.Vector2Tests" method="Vector2ConstructorTest4" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SubtractionByte" type="System.Numerics.Tests.GenericVectorTests" method="SubtractionByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4MultiplyTest4" type="System.Numerics.Tests.Vector4Tests" method="Vector4MultiplyTest4" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2ReflectTest2" type="System.Numerics.Tests.Vector2Tests" method="Vector2ReflectTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorDefaultInt16" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorDefaultInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4MultiplyTest3" type="System.Numerics.Tests.Vector4Tests" method="Vector4MultiplyTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3EqualsTest1" type="System.Numerics.Tests.Vector3Tests" method="Vector3EqualsTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2UnitXTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2UnitXTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionLengthTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionLengthTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanAnyByte" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanAnyByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4LerpTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4LerpTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2ZeroTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2ZeroTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationWithScalarSingle" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationWithScalarSingle" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorArrayReflectionInt32" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorArrayReflectionInt32" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionIdentityTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionIdentityTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToWithOffsetReflectionInt64" type="System.Numerics.Tests.GenericVectorTests" method="CopyToWithOffsetReflectionInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationWithScalarInt32" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationWithScalarInt32" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualAllDouble" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualAllDouble" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualInt64" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2DistanceTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2DistanceTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsAllUInt32" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsAllUInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToWithOffsetSingle" type="System.Numerics.Tests.GenericVectorTests" method="CopyToWithOffsetSingle" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringCurrencyByte" type="System.Numerics.Tests.GenericVectorTests" method="ToStringCurrencyByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DotProductSByte" type="System.Numerics.Tests.GenericVectorTests" method="DotProductSByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2TranslationTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2TranslationTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4FromQuaternionTest5" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4FromQuaternionTest5" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2ConstructorTest2" type="System.Numerics.Tests.Vector2Tests" method="Vector2ConstructorTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateFromYawPitchRollTest2" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateFromYawPitchRollTest2" time="0,118" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseOnesComplementOperatorUInt64" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseOnesComplementOperatorUInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4TransposeTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4TransposeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsAllUInt64" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsAllUInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToWithOffsetReflectionUInt32" type="System.Numerics.Tests.GenericVectorTests" method="CopyToWithOffsetReflectionUInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GetHashCodeUInt16" type="System.Numerics.Tests.GenericVectorTests" method="GetHashCodeUInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualAnyUInt16" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualAnyUInt16" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4SubtractTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4SubtractTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4DivisionTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4DivisionTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3MultiplyTest1" type="System.Numerics.Tests.Vector3Tests" method="Vector3MultiplyTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseAndNotUInt32" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseAndNotUInt32" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4MultiplyTest3" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4MultiplyTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4MultiplyTest6" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4MultiplyTest6" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanAnySByte" type="System.Numerics.Tests.GenericVectorTests" method="LessThanAnySByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseXorOperatorUInt64" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseXorOperatorUInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanAnyInt16" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanAnyInt16" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.StaticOneVectorByte" type="System.Numerics.Tests.GenericVectorTests" method="StaticOneVectorByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationWithScalarSByte" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationWithScalarSByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MaxInt16" type="System.Numerics.Tests.GenericVectorTests" method="MaxInt16" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateOrthoTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateOrthoTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2CreateSkewYTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2CreateSkewYTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4TranslationTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4TranslationTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringGeneralSingle" type="System.Numerics.Tests.GenericVectorTests" method="ToStringGeneralSingle" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanAnyUInt16" type="System.Numerics.Tests.GenericVectorTests" method="LessThanAnyUInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanAllSingle" type="System.Numerics.Tests.GenericVectorTests" method="LessThanAllSingle" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanAllInt64" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanAllInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToWithOffsetReflectionUInt64" type="System.Numerics.Tests.GenericVectorTests" method="CopyToWithOffsetReflectionUInt64" time="0,012" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConditionalSelectSByte" type="System.Numerics.Tests.GenericVectorTests" method="ConditionalSelectSByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanSByte" type="System.Numerics.Tests.GenericVectorTests" method="LessThanSByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4SubtractTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4SubtractTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3OneTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3OneTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionLerpTest1" type="System.Numerics.Tests.QuaternionTests" method="QuaternionLerpTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4LengthTest1" type="System.Numerics.Tests.Vector4Tests" method="Vector4LengthTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.EqualsObjectInt64" type="System.Numerics.Tests.GenericVectorTests" method="EqualsObjectInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MinUInt64" type="System.Numerics.Tests.GenericVectorTests" method="MinUInt64" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2InequalityTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2InequalityTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorGreaterThanSByte" type="System.Numerics.Tests.GenericVectorTests" method="VectorGreaterThanSByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3LerpTest4" type="System.Numerics.Tests.Vector3Tests" method="Vector3LerpTest4" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorSingleValueReflectionInt64" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorSingleValueReflectionInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseAndNotByte" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseAndNotByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4InvertRotationTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4InvertRotationTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3TransformByQuaternionTest1" type="System.Numerics.Tests.Vector3Tests" method="Vector3TransformByQuaternionTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationWithScalarByte" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationWithScalarByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualInt64" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualInt64" time="0,006" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4UnaryNegationTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4UnaryNegationTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreatePerspectiveFieldOfViewTest2" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreatePerspectiveFieldOfViewTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MinSByte" type="System.Numerics.Tests.GenericVectorTests" method="MinSByte" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringCurrencySingle" type="System.Numerics.Tests.GenericVectorTests" method="ToStringCurrencySingle" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualAllInt32" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualAllInt32" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3EqualsNanTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3EqualsNanTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3ConstructorTest5" type="System.Numerics.Tests.Vector3Tests" method="Vector3ConstructorTest5" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToSingle" type="System.Numerics.Tests.GenericVectorTests" method="CopyToSingle" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MaxInt32" type="System.Numerics.Tests.GenericVectorTests" method="MaxInt32" time="0,033" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateConstrainedBillboardTooCloseTest2" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateConstrainedBillboardTooCloseTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToReflectionUInt64" type="System.Numerics.Tests.GenericVectorTests" method="CopyToReflectionUInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseOnesComplementOperatorUInt32" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseOnesComplementOperatorUInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GetHashCodeSByte" type="System.Numerics.Tests.GenericVectorTests" method="GetHashCodeSByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanAllInt16" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanAllInt16" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4ToStringTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4ToStringTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreatePerspectiveTest4" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreatePerspectiveTest4" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2LengthSquaredTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2LengthSquaredTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsAnyDouble" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsAnyDouble" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AbsDouble" type="System.Numerics.Tests.GenericVectorTests" method="AbsDouble" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionEqualsTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionEqualsTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionNormalizeTest1" type="System.Numerics.Tests.QuaternionTests" method="QuaternionNormalizeTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4TransformVector4QuaternionTest2" type="System.Numerics.Tests.Vector4Tests" method="Vector4TransformVector4QuaternionTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateLookAtTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateLookAtTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateConstrainedBillboardTest07" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateConstrainedBillboardTest07" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringGeneralUInt64" type="System.Numerics.Tests.GenericVectorTests" method="ToStringGeneralUInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorGreaterThanUInt64" type="System.Numerics.Tests.GenericVectorTests" method="VectorGreaterThanUInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreatePerspectiveOffCenterTest3" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreatePerspectiveOffCenterTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateBillboardTest03" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateBillboardTest03" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DotProductSingle" type="System.Numerics.Tests.GenericVectorTests" method="DotProductSingle" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionByZeroExceptionByte" type="System.Numerics.Tests.GenericVectorTests" method="DivisionByZeroExceptionByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionCreateFromAxisAngleTest3" type="System.Numerics.Tests.QuaternionTests" method="QuaternionCreateFromAxisAngleTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualAnyInt64" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualAnyInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.PlaneTests.PlaneCreateFromVerticesTest" type="System.Numerics.Tests.PlaneTests" method="PlaneCreateFromVerticesTest" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorExceptionDouble" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorExceptionDouble" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MinInt16" type="System.Numerics.Tests.GenericVectorTests" method="MinInt16" time="0,006" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.IndexerOutOfRangeUInt32" type="System.Numerics.Tests.GenericVectorTests" method="IndexerOutOfRangeUInt32" time="0,008" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionSlerpTest4" type="System.Numerics.Tests.QuaternionTests" method="QuaternionSlerpTest4" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorWithOffsetInt32" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorWithOffsetInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateConstrainedBillboardTest10" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateConstrainedBillboardTest10" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4MinTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4MinTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.EqualsVectorByte" type="System.Numerics.Tests.GenericVectorTests" method="EqualsVectorByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4TransformVector4QuaternionTest1" type="System.Numerics.Tests.Vector4Tests" method="Vector4TransformVector4QuaternionTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3LerpTest1" type="System.Numerics.Tests.Vector3Tests" method="Vector3LerpTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2LerpTest1" type="System.Numerics.Tests.Vector2Tests" method="Vector2LerpTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorArrayReflectionUInt16" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorArrayReflectionUInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationUInt16" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationUInt16" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4SubtractionTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4SubtractionTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.UnaryMinusByte" type="System.Numerics.Tests.GenericVectorTests" method="UnaryMinusByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3ReflectTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3ReflectTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorArrayReflectionUInt32" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorArrayReflectionUInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateFromAxisAngleTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateFromAxisAngleTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionReflectionDouble" type="System.Numerics.Tests.GenericVectorTests" method="DivisionReflectionDouble" time="0,006" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2SqrtTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2SqrtTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateConstrainedBillboardTest05" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateConstrainedBillboardTest05" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionMultiplyTest1" type="System.Numerics.Tests.QuaternionTests" method="QuaternionMultiplyTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringCurrencyInt16" type="System.Numerics.Tests.GenericVectorTests" method="ToStringCurrencyInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4MarshalSizeTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4MarshalSizeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2TransformByQuaternionTest1" type="System.Numerics.Tests.Vector2Tests" method="Vector2TransformByQuaternionTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorConstantValueUInt16" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorConstantValueUInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationReflectionSingle" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationReflectionSingle" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3LengthTest1" type="System.Numerics.Tests.Vector3Tests" method="Vector3LengthTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringExponentialUInt16" type="System.Numerics.Tests.GenericVectorTests" method="ToStringExponentialUInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4UnitZTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4UnitZTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4MultiplyTest2" type="System.Numerics.Tests.Vector4Tests" method="Vector4MultiplyTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3TransformByQuaternionTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3TransformByQuaternionTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanAnyUInt16" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanAnyUInt16" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationDouble" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationDouble" time="0,006" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanAnyInt32" type="System.Numerics.Tests.GenericVectorTests" method="LessThanAnyInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4IdentityTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4IdentityTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2DivisionTest3" type="System.Numerics.Tests.Vector2Tests" method="Vector2DivisionTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4LerpTest3" type="System.Numerics.Tests.Vector4Tests" method="Vector4LerpTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MaxByte" type="System.Numerics.Tests.GenericVectorTests" method="MaxByte" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2InvertRotationTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2InvertRotationTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2EqualityTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2EqualityTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2EqualsNanTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2EqualsNanTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2DotTest1" type="System.Numerics.Tests.Vector2Tests" method="Vector2DotTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2DeterminantTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2DeterminantTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2InequalityTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2InequalityTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConditionalSelectUInt32" type="System.Numerics.Tests.GenericVectorTests" method="ConditionalSelectUInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionReflectionUInt16" type="System.Numerics.Tests.GenericVectorTests" method="DivisionReflectionUInt16" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2MinMaxCodeCoverageTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2MinMaxCodeCoverageTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SubtractionOverflowByte" type="System.Numerics.Tests.GenericVectorTests" method="SubtractionOverflowByte" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateOrthoOffCenterTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateOrthoOffCenterTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.StaticOneVectorDouble" type="System.Numerics.Tests.GenericVectorTests" method="StaticOneVectorDouble" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToInt16" type="System.Numerics.Tests.GenericVectorTests" method="CopyToInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3CrossTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3CrossTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.EqualsObjectByte" type="System.Numerics.Tests.GenericVectorTests" method="EqualsObjectByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanSingle" type="System.Numerics.Tests.GenericVectorTests" method="LessThanSingle" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanAnyUInt32" type="System.Numerics.Tests.GenericVectorTests" method="LessThanAnyUInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2MultiplyTest6" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2MultiplyTest6" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MaxInt64" type="System.Numerics.Tests.GenericVectorTests" method="MaxInt64" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.EqualsVectorSingle" type="System.Numerics.Tests.GenericVectorTests" method="EqualsVectorSingle" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualInt16" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4MultiplyTest1" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4MultiplyTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4LerpTest5" type="System.Numerics.Tests.Vector4Tests" method="Vector4LerpTest5" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.IndexerOutOfRangeInt32" type="System.Numerics.Tests.GenericVectorTests" method="IndexerOutOfRangeInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateBillboardTest11" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateBillboardTest11" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsAllInt32" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsAllInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualAnyInt32" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualAnyInt32" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AbsByte" type="System.Numerics.Tests.GenericVectorTests" method="AbsByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanAnySingle" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanAnySingle" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2SubtractTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2SubtractTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2TransformNormalTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2TransformNormalTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateBillboardTest06" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateBillboardTest06" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3DistanceTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3DistanceTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2LengthTest1" type="System.Numerics.Tests.Vector2Tests" method="Vector2LengthTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4TransformTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4TransformTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3UnaryNegationTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3UnaryNegationTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualAllUInt64" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualAllUInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationReflectionInt16" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationReflectionInt16" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionDivisionTest1" type="System.Numerics.Tests.QuaternionTests" method="QuaternionDivisionTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2GetHashCodeTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2GetHashCodeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.EqualsVectorSByte" type="System.Numerics.Tests.GenericVectorTests" method="EqualsVectorSByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorSByte" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorSByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseXorOperatorInt32" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseXorOperatorInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4InvertTest1" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4InvertTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2OneTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2OneTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorExceptionInt64" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorExceptionInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorGreaterThanInt64" type="System.Numerics.Tests.GenericVectorTests" method="VectorGreaterThanInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorWithOffsetSingle" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorWithOffsetSingle" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3MinTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3MinTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.StaticOneVectorUInt16" type="System.Numerics.Tests.GenericVectorTests" method="StaticOneVectorUInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorSingleValueReflectionUInt64" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorSingleValueReflectionUInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionReflectionDouble" type="System.Numerics.Tests.GenericVectorTests" method="AdditionReflectionDouble" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionFromRotationMatrixTest3" type="System.Numerics.Tests.QuaternionTests" method="QuaternionFromRotationMatrixTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3DivisionTest3" type="System.Numerics.Tests.Vector3Tests" method="Vector3DivisionTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToWithOffsetUInt32" type="System.Numerics.Tests.GenericVectorTests" method="CopyToWithOffsetUInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseAndOperatorUInt64" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseAndOperatorUInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseXorOperatorUInt32" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseXorOperatorUInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringCurrencyUInt64" type="System.Numerics.Tests.GenericVectorTests" method="ToStringCurrencyUInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorWithOffsetDouble" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorWithOffsetDouble" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateBillboardTooCloseTest2" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateBillboardTooCloseTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseOrOperatorUInt16" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseOrOperatorUInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3DivideTest1" type="System.Numerics.Tests.Vector3Tests" method="Vector3DivideTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionInverseTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionInverseTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorGreaterThanInt32" type="System.Numerics.Tests.GenericVectorTests" method="VectorGreaterThanInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DotProductInt16" type="System.Numerics.Tests.GenericVectorTests" method="DotProductInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SquareRootUInt64" type="System.Numerics.Tests.GenericVectorTests" method="SquareRootUInt64" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorSingleValueReflectionInt16" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorSingleValueReflectionInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4EqualsTest1" type="System.Numerics.Tests.Vector4Tests" method="Vector4EqualsTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2UnitYTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2UnitYTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3MultiplyTest3" type="System.Numerics.Tests.Vector3Tests" method="Vector3MultiplyTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorArrayReflectionInt64" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorArrayReflectionInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorExceptionUInt32" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorExceptionUInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionLerpTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionLerpTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionInequalityTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionInequalityTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2InvertTest1" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2InvertTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringExponentialDouble" type="System.Numerics.Tests.GenericVectorTests" method="ToStringExponentialDouble" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionReflectionInt16" type="System.Numerics.Tests.GenericVectorTests" method="DivisionReflectionInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MinInt32" type="System.Numerics.Tests.GenericVectorTests" method="MinInt32" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.PlaneTests.PlaneEqualsTest" type="System.Numerics.Tests.PlaneTests" method="PlaneEqualsTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4NegateTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4NegateTest" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2Transform3x2Test" type="System.Numerics.Tests.Vector2Tests" method="Vector2Transform3x2Test" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorDefaultUInt32" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorDefaultUInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4UnitXTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4UnitXTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3CopyToTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3CopyToTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualUInt64" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualUInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.StaticOneVectorSByte" type="System.Numerics.Tests.GenericVectorTests" method="StaticOneVectorSByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionReflectionSByte" type="System.Numerics.Tests.GenericVectorTests" method="AdditionReflectionSByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.StaticOneVectorSingle" type="System.Numerics.Tests.GenericVectorTests" method="StaticOneVectorSingle" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanAllUInt16" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanAllUInt16" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionMultiplyTest3" type="System.Numerics.Tests.QuaternionTests" method="QuaternionMultiplyTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreatePerspectiveOffCenterTest1" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreatePerspectiveOffCenterTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsAnyInt16" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsAnyInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SubtractionOverflowInt64" type="System.Numerics.Tests.GenericVectorTests" method="SubtractionOverflowInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringCurrencyInt64" type="System.Numerics.Tests.GenericVectorTests" method="ToStringCurrencyInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4SizeofTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4SizeofTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4OneTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4OneTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3UnaryNegationTest1" type="System.Numerics.Tests.Vector3Tests" method="Vector3UnaryNegationTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3MultiplyTest2" type="System.Numerics.Tests.Vector3Tests" method="Vector3MultiplyTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToWithOffsetUInt16" type="System.Numerics.Tests.GenericVectorTests" method="CopyToWithOffsetUInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.EqualsVectorInt64" type="System.Numerics.Tests.GenericVectorTests" method="EqualsVectorInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionReflectionSingle" type="System.Numerics.Tests.GenericVectorTests" method="AdditionReflectionSingle" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToReflectionSByte" type="System.Numerics.Tests.GenericVectorTests" method="CopyToReflectionSByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseOnesComplementOperatorUInt16" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseOnesComplementOperatorUInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanAllInt32" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanAllInt32" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionReflectionUInt32" type="System.Numerics.Tests.GenericVectorTests" method="DivisionReflectionUInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.UnaryMinusInt16" type="System.Numerics.Tests.GenericVectorTests" method="UnaryMinusInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2TransformTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2TransformTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualAnyUInt32" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualAnyUInt32" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionEqualsNanTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionEqualsNanTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseAndNotInt16" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseAndNotInt16" time="0,002" result="Pass" />
+    </collection>
+    <collection total="1039" passed="1039" failed="0" skipped="0" name="xUnit.net v1 Tests for D:\Dev\corefx\bin\Release\System.Numerics.Vectors.Tests\System.Numerics.Vectors.Tests.dll" time="2,277">
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionReflectionInt64" type="System.Numerics.Tests.GenericVectorTests" method="AdditionReflectionInt64" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2CreateRotationRightAngleTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2CreateRotationRightAngleTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2InvertAffineTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2InvertAffineTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3ClampTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3ClampTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorSingleValueReflectionSingle" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorSingleValueReflectionSingle" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4AddTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4AddTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4LerpTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4LerpTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorGreaterThanByte" type="System.Numerics.Tests.GenericVectorTests" method="VectorGreaterThanByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SubtractionUInt32" type="System.Numerics.Tests.GenericVectorTests" method="SubtractionUInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4DecomposeTest01" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4DecomposeTest01" time="0,595" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3AbsTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3AbsTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2ConstructorTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2ConstructorTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualUInt16" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualUInt16" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2DistanceTest2" type="System.Numerics.Tests.Vector2Tests" method="Vector2DistanceTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringGeneralDouble" type="System.Numerics.Tests.GenericVectorTests" method="ToStringGeneralDouble" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualAnyByte" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualAnyByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4EqualsNanTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4EqualsNanTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionOverflowInt16" type="System.Numerics.Tests.GenericVectorTests" method="AdditionOverflowInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringExponentialSByte" type="System.Numerics.Tests.GenericVectorTests" method="ToStringExponentialSByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateBillboardTest09" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateBillboardTest09" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2InvertTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2InvertTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2DivisionTest1" type="System.Numerics.Tests.Vector2Tests" method="Vector2DivisionTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2CreateRotationRightAngleCenterTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2CreateRotationRightAngleCenterTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4GetHashCodeTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4GetHashCodeTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2TransformByQuaternionTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2TransformByQuaternionTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2DistanceSquaredTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2DistanceSquaredTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.StaticZeroVectorUInt32" type="System.Numerics.Tests.GenericVectorTests" method="StaticZeroVectorUInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionInt32" type="System.Numerics.Tests.GenericVectorTests" method="AdditionInt32" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2SizeofTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2SizeofTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseXorOperatorSByte" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseXorOperatorSByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SubtractionSByte" type="System.Numerics.Tests.GenericVectorTests" method="SubtractionSByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateConstrainedBillboardTest11" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateConstrainedBillboardTest11" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanAllUInt32" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanAllUInt32" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.UnaryMinusSingle" type="System.Numerics.Tests.GenericVectorTests" method="UnaryMinusSingle" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2AdditionTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2AdditionTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseAndNotSByte" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseAndNotSByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4AdditionTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4AdditionTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4TransformVector3Quaternion" type="System.Numerics.Tests.Vector4Tests" method="Vector4TransformVector3Quaternion" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionInt64" type="System.Numerics.Tests.GenericVectorTests" method="AdditionInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2InvertScaleTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2InvertScaleTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorWithOffsetUInt32" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorWithOffsetUInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorSingleValueReflectionSByte" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorSingleValueReflectionSByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorDouble" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorDouble" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3ReflectTest2" type="System.Numerics.Tests.Vector3Tests" method="Vector3ReflectTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SquareRootSByte" type="System.Numerics.Tests.GenericVectorTests" method="SquareRootSByte" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MaxSingle" type="System.Numerics.Tests.GenericVectorTests" method="MaxSingle" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4AdditionTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4AdditionTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4EqualityTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4EqualityTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2CopyToTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2CopyToTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionGetHashCodeTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionGetHashCodeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateConstrainedBillboardAlongAxisTest3" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateConstrainedBillboardAlongAxisTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2EqualityTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2EqualityTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualUInt32" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualUInt32" time="0,007" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2UnaryNegationTest1" type="System.Numerics.Tests.Vector2Tests" method="Vector2UnaryNegationTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2CreateSkewCenterTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2CreateSkewCenterTest" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToReflectionUInt16" type="System.Numerics.Tests.GenericVectorTests" method="CopyToReflectionUInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseOrOperatorByte" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseOrOperatorByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConditionalSelectInt64" type="System.Numerics.Tests.GenericVectorTests" method="ConditionalSelectInt64" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateFromYawPitchRollTest1" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateFromYawPitchRollTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreatePerspectiveFieldOfViewTest3" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreatePerspectiveFieldOfViewTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionSlerpTest2" type="System.Numerics.Tests.QuaternionTests" method="QuaternionSlerpTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanAnySingle" type="System.Numerics.Tests.GenericVectorTests" method="LessThanAnySingle" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2LerpTest5" type="System.Numerics.Tests.Vector2Tests" method="Vector2LerpTest5" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanAllDouble" type="System.Numerics.Tests.GenericVectorTests" method="LessThanAllDouble" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsAnyInt64" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsAnyInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3NegateTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3NegateTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionReflectionInt16" type="System.Numerics.Tests.GenericVectorTests" method="AdditionReflectionInt16" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualAllInt32" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualAllInt32" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4TransformVector3Test2" type="System.Numerics.Tests.Vector4Tests" method="Vector4TransformVector3Test2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.EqualsObjectSingle" type="System.Numerics.Tests.GenericVectorTests" method="EqualsObjectSingle" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GetHashCodeInt32" type="System.Numerics.Tests.GenericVectorTests" method="GetHashCodeInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3InequalityTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3InequalityTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SubtractionUInt64" type="System.Numerics.Tests.GenericVectorTests" method="SubtractionUInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.PlaneTests.PlaneGetHashCodeTest" type="System.Numerics.Tests.PlaneTests" method="PlaneGetHashCodeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanAllSingle" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanAllSingle" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4ClampTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4ClampTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorUInt32" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorUInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConditionalSelectInt32" type="System.Numerics.Tests.GenericVectorTests" method="ConditionalSelectInt32" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.IndexerOutOfRangeInt16" type="System.Numerics.Tests.GenericVectorTests" method="IndexerOutOfRangeInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorConstantValueInt16" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorConstantValueInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4DeterminantTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4DeterminantTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4TransformVector3QuaternionTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4TransformVector3QuaternionTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseOnesComplementOperatorInt32" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseOnesComplementOperatorInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionReflectionUInt64" type="System.Numerics.Tests.GenericVectorTests" method="AdditionReflectionUInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionOverflowUInt32" type="System.Numerics.Tests.GenericVectorTests" method="AdditionOverflowUInt32" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorDefaultSingle" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorDefaultSingle" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreatePerspectiveTest1" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreatePerspectiveTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.UnaryMinusSByte" type="System.Numerics.Tests.GenericVectorTests" method="UnaryMinusSByte" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanOrEqualDouble" type="System.Numerics.Tests.GenericVectorTests" method="LessThanOrEqualDouble" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.BitwiseOrOperatorInt32" type="System.Numerics.Tests.GenericVectorTests" method="BitwiseOrOperatorInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionToStringTest" type="System.Numerics.Tests.QuaternionTests" method="QuaternionToStringTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3SubtractTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3SubtractTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2NormalizeTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2NormalizeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.PlaneTests.PlaneTransformTest2" type="System.Numerics.Tests.PlaneTests" method="PlaneTransformTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.EqualsVectorUInt64" type="System.Numerics.Tests.GenericVectorTests" method="EqualsVectorUInt64" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4TransformVector2QuatanionTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4TransformVector2QuatanionTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4DivideTest1" type="System.Numerics.Tests.Vector4Tests" method="Vector4DivideTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreatePerspectiveFieldOfViewTest" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreatePerspectiveFieldOfViewTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.OperatorAddTest" type="System.Numerics.Tests.Vector4Tests" method="OperatorAddTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3ToStringTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3ToStringTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2TransformByQuaternionTest2" type="System.Numerics.Tests.Vector2Tests" method="Vector2TransformByQuaternionTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3NormalizeTest2" type="System.Numerics.Tests.Vector3Tests" method="Vector3NormalizeTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2MarshalSizeTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2MarshalSizeTest" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanAnyByte" type="System.Numerics.Tests.GenericVectorTests" method="LessThanAnyByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4MultiplyTest4" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4MultiplyTest4" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2LerpTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2LerpTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionFromRotationMatrixWithScaledMatrixTest1" type="System.Numerics.Tests.QuaternionTests" method="QuaternionFromRotationMatrixWithScaledMatrixTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanOrEqualAllDouble" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanOrEqualAllDouble" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.SquareRootSingle" type="System.Numerics.Tests.GenericVectorTests" method="SquareRootSingle" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringCurrencyUInt16" type="System.Numerics.Tests.GenericVectorTests" method="ToStringCurrencyUInt16" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanAllInt64" type="System.Numerics.Tests.GenericVectorTests" method="LessThanAllInt64" time="0,006" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToWithOffsetByte" type="System.Numerics.Tests.GenericVectorTests" method="CopyToWithOffsetByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.VectorEqualsAnyByte" type="System.Numerics.Tests.GenericVectorTests" method="VectorEqualsAnyByte" time="0,011" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorDefaultSByte" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorDefaultSByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationSByte" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationSByte" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4LerpTest1" type="System.Numerics.Tests.Vector4Tests" method="Vector4LerpTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector3Tests.Vector3DistanceSquaredTest" type="System.Numerics.Tests.Vector3Tests" method="Vector3DistanceSquaredTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ToStringExponentialUInt32" type="System.Numerics.Tests.GenericVectorTests" method="ToStringExponentialUInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionUInt16" type="System.Numerics.Tests.GenericVectorTests" method="DivisionUInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.PlaneTests.PlaneCreateFromVerticesTest2" type="System.Numerics.Tests.PlaneTests" method="PlaneCreateFromVerticesTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4SqrtTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4SqrtTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionOverflowInt32" type="System.Numerics.Tests.GenericVectorTests" method="AdditionOverflowInt32" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationSingle" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationSingle" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2MultiplyTest4" type="System.Numerics.Tests.Vector2Tests" method="Vector2MultiplyTest4" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GetHashCodeByte" type="System.Numerics.Tests.GenericVectorTests" method="GetHashCodeByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.LessThanAnyInt16" type="System.Numerics.Tests.GenericVectorTests" method="LessThanAnyInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanAnyDouble" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanAnyDouble" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorArrayReflectionInt16" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorArrayReflectionInt16" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2LerpTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2LerpTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.GreaterThanAllSByte" type="System.Numerics.Tests.GenericVectorTests" method="GreaterThanAllSByte" time="0,010" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2CreateScaleTest2" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2CreateScaleTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2DivisionTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2DivisionTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorInt32" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorInt32" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4ZeroTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4ZeroTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2GetHashCodeTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2GetHashCodeTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.ConstructorConstantValueSingle" type="System.Numerics.Tests.GenericVectorTests" method="ConstructorConstantValueSingle" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.AdditionOverflowSByte" type="System.Numerics.Tests.GenericVectorTests" method="AdditionOverflowSByte" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4From3x2Test" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4From3x2Test" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2AddTest" type="System.Numerics.Tests.Vector2Tests" method="Vector2AddTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.DeeplyEmbeddedStructTest" type="System.Numerics.Tests.Vector4Tests" method="DeeplyEmbeddedStructTest" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.QuaternionTests.QuaternionFromRotationMatrixWithScaledMatrixTest3" type="System.Numerics.Tests.QuaternionTests" method="QuaternionFromRotationMatrixWithScaledMatrixTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.IndexerOutOfRangeSByte" type="System.Numerics.Tests.GenericVectorTests" method="IndexerOutOfRangeSByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.MultiplicationByte" type="System.Numerics.Tests.GenericVectorTests" method="MultiplicationByte" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix4x4Tests.Matrix4x4CreateScaleCenterTest3" type="System.Numerics.Tests.Matrix4x4Tests" method="Matrix4x4CreateScaleCenterTest3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Matrix3x2Tests.Matrix3x2AddTest" type="System.Numerics.Tests.Matrix3x2Tests" method="Matrix3x2AddTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2DotTest2" type="System.Numerics.Tests.Vector2Tests" method="Vector2DotTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.CopyToReflectionSingle" type="System.Numerics.Tests.GenericVectorTests" method="CopyToReflectionSingle" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector4Tests.Vector4UnitWTest" type="System.Numerics.Tests.Vector4Tests" method="Vector4UnitWTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.DivisionByZeroExceptionSByte" type="System.Numerics.Tests.GenericVectorTests" method="DivisionByZeroExceptionSByte" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.Vector2Tests.Vector2TransformNormal3x2Test" type="System.Numerics.Tests.Vector2Tests" method="Vector2TransformNormal3x2Test" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Numerics.Tests.GenericVectorTests.StaticZeroVectorSByte" type="System.Numerics.Tests.GenericVectorTests" method="StaticZeroVectorSByte" time="0,000" result="Pass" />
+    </collection>
+  </assembly>
+  <assembly name="D:\Dev\corefx\bin\Release\System.Reflection.Metadata.Tests\System.Reflection.Metadata.Tests.dll" environment="32-bit .NET 4.0.30319.34014" test-framework="xUnit.net 1.9.2.1705" run-date="2014-11-15" run-time="17:25:52" total="90" passed="90" failed="0" skipped="0" time="0,544" errors="0">
+    <errors />
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.MemberCollections_TypeMembers_MiddleTypeDef" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="MemberCollections_TypeMembers_MiddleTypeDef" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.CompressedIntegerTests.DecompressInvalidSignedIntegers" type="System.Reflection.Metadata.Tests.CompressedIntegerTests" method="DecompressInvalidSignedIntegers" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateNamespaceFunctionality" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateNamespaceFunctionality" time="0,024" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.HandleTests.HandleKindHidesSpecialStringAndNamespaces" type="System.Reflection.Metadata.Tests.HandleTests" method="HandleKindHidesSpecialStringAndNamespaces" time="0,006" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateNamespaceCacheLaziness" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateNamespaceCacheLaziness" time="0,007" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateUserStringStream" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateUserStringStream" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.PEReaderTests.Ctor" type="System.Reflection.Metadata.Tests.PEReaderTests" method="Ctor" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MemoryBlockTests.Utf8NullTerminatedString_Comparisons" type="System.Reflection.Metadata.Tests.MemoryBlockTests" method="Utf8NullTerminatedString_Comparisons" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateModuleRefTableMod" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateModuleRefTableMod" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateTypeRefTableMod" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateTypeRefTableMod" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateMethodImplTable" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateMethodImplTable" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.CannotInstantiateReaderWithNonUtf8Decoder" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="CannotInstantiateReaderWithNonUtf8Decoder" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateTypeSpecTableMod" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateTypeSpecTableMod" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.AbstractMemoryBlockTests.FileStreamWin7" type="System.Reflection.Metadata.Tests.AbstractMemoryBlockTests" method="FileStreamWin7" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataTokensTests.GetToken" type="System.Reflection.Metadata.Tests.MetadataTokensTests" method="GetToken" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MemoryBlockTests.BuildPtrTable_SmallRefs" type="System.Reflection.Metadata.Tests.MemoryBlockTests" method="BuildPtrTable_SmallRefs" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataAggregatorTests.HeapSizes" type="System.Reflection.Metadata.Tests.MetadataAggregatorTests" method="HeapSizes" time="0,143" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.BlobReaderTests.ReadFromMemoryReader" type="System.Reflection.Metadata.Tests.BlobReaderTests" method="ReadFromMemoryReader" time="0,013" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.Handles" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="Handles" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateClassLayoutTable" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateClassLayoutTable" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.BadImageFormat.InvalidSectionCount" type="System.Reflection.Metadata.Tests.BadImageFormat" method="InvalidSectionCount" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.StreamExtensionsTests.CopyTo3" type="System.Reflection.Metadata.Tests.StreamExtensionsTests" method="CopyTo3" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateMemberRefTableMod" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateMemberRefTableMod" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MemoryBlockTests.BinarySearch" type="System.Reflection.Metadata.Tests.MemoryBlockTests" method="BinarySearch" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataTokensTests.GetHeapOffset" type="System.Reflection.Metadata.Tests.MetadataTokensTests" method="GetHeapOffset" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.EmptyMetadata" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="EmptyMetadata" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateFieldMarshal" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateFieldMarshal" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.BlobReaderTests.ReadFromMemoryBlock" type="System.Reflection.Metadata.Tests.BlobReaderTests" method="ReadFromMemoryBlock" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.AbstractMemoryBlockTests.FileStream450" type="System.Reflection.Metadata.Tests.AbstractMemoryBlockTests" method="FileStream450" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateAssemblyRefTable" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateAssemblyRefTable" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.MemberCollections_TypeMembers_FirstTypeDef" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="MemberCollections_TypeMembers_FirstTypeDef" time="0,015" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.AbstractMemoryBlockTests.ByteArray" type="System.Reflection.Metadata.Tests.AbstractMemoryBlockTests" method="ByteArray" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.BlobReaderTests.ValidatePeekReferenceSize" type="System.Reflection.Metadata.Tests.BlobReaderTests" method="ValidatePeekReferenceSize" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateSignature" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateSignature" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.EmptyType" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="EmptyType" time="0,001" result="Pass" />
+    </collection>
+    <collection total="90" passed="90" failed="0" skipped="0" name="xUnit.net v1 Tests for D:\Dev\corefx\bin\Release\System.Reflection.Metadata.Tests\System.Reflection.Metadata.Tests.dll" time="0,544">
+      <test name="System.Reflection.Metadata.Tests.MetadataAggregatorTests.RowCounts" type="System.Reflection.Metadata.Tests.MetadataAggregatorTests" method="RowCounts" time="0,007" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateTypeSpecTable" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateTypeSpecTable" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateModuleRefTableAndFileTableManaged" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateModuleRefTableAndFileTableManaged" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MemoryBlockTests.EncodingLightUpHasSucceededAndTestsStillPassWithPortableFallbackAsWell" type="System.Reflection.Metadata.Tests.MemoryBlockTests" method="EncodingLightUpHasSucceededAndTestsStillPassWithPortableFallbackAsWell" time="0,029" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.CompressedIntegerTests.CompressUnsignedIntegersFromSpecExamples" type="System.Reflection.Metadata.Tests.CompressedIntegerTests" method="CompressUnsignedIntegersFromSpecExamples" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateTypeDefTable" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateTypeDefTable" time="0,020" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.StreamLengths" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="StreamLengths" time="0,006" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MemoryBlockTests.DefaultDecodingFallbackMatchesBcl" type="System.Reflection.Metadata.Tests.MemoryBlockTests" method="DefaultDecodingFallbackMatchesBcl" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.MemberCollections_AllMembers" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="MemberCollections_AllMembers" time="0,005" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataTokensTests.GetRowNumber" type="System.Reflection.Metadata.Tests.MetadataTokensTests" method="GetRowNumber" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.PEReaderTests.EntireImage_LazyLoad" type="System.Reflection.Metadata.Tests.PEReaderTests" method="EntireImage_LazyLoad" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.PEReaderTests.Metadata_EagerLoad" type="System.Reflection.Metadata.Tests.PEReaderTests" method="Metadata_EagerLoad" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.AbstractMemoryBlockTests.External" type="System.Reflection.Metadata.Tests.AbstractMemoryBlockTests" method="External" time="0,008" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.PEReaderTests.Metadata_LazyLoad" type="System.Reflection.Metadata.Tests.PEReaderTests" method="Metadata_LazyLoad" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.AbstractMemoryBlockTests.Stream" type="System.Reflection.Metadata.Tests.AbstractMemoryBlockTests" method="Stream" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.BlobReaderTests.PublicBlobReaderCtorValidatesArgs" type="System.Reflection.Metadata.Tests.BlobReaderTests" method="PublicBlobReaderCtorValidatesArgs" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.PEReaderTests.IL_LazyLoad" type="System.Reflection.Metadata.Tests.PEReaderTests" method="IL_LazyLoad" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MemoryBlockTests.BuildPtrTable_LargeRefs" type="System.Reflection.Metadata.Tests.MemoryBlockTests" method="BuildPtrTable_LargeRefs" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.PEReaderTests.EntireImage_EagerLoad" type="System.Reflection.Metadata.Tests.PEReaderTests" method="EntireImage_EagerLoad" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateTypeRefTable" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateTypeRefTable" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MemoryBlockTests.DecodingSuccessMatchesBcl" type="System.Reflection.Metadata.Tests.MemoryBlockTests" method="DecodingSuccessMatchesBcl" time="0,007" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateConstantTable" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateConstantTable" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateModuleTable" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateModuleTable" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.CompressedIntegerTests.DecompressSignedIntegersFromSpecExamples" type="System.Reflection.Metadata.Tests.CompressedIntegerTests" method="DecompressSignedIntegersFromSpecExamples" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateGenericParamTable" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateGenericParamTable" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateTypeDefTableMod" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateTypeDefTableMod" time="0,007" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MemoryBlockTests.LightUpTrickFromDifferentAssemblyWorks" type="System.Reflection.Metadata.Tests.MemoryBlockTests" method="LightUpTrickFromDifferentAssemblyWorks" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.AbstractMemoryBlockTests.FileStreamUnix" type="System.Reflection.Metadata.Tests.AbstractMemoryBlockTests" method="FileStreamUnix" time="0,024" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.CompressedIntegerTests.CheckCompressedUnsignedIntegers" type="System.Reflection.Metadata.Tests.CompressedIntegerTests" method="CheckCompressedUnsignedIntegers" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateAssemblyTableExe" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateAssemblyTableExe" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.CompressedIntegerTests.CompressSignedIntegersFromSpecExamples" type="System.Reflection.Metadata.Tests.CompressedIntegerTests" method="CompressSignedIntegersFromSpecExamples" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.StreamExtensionsTests.CopyTo1" type="System.Reflection.Metadata.Tests.StreamExtensionsTests" method="CopyTo1" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.PEReaderTests.IL_EagerLoad" type="System.Reflection.Metadata.Tests.PEReaderTests" method="IL_EagerLoad" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MemoryBlockTests.Utf8NullTermintatedStringStartsWithAsciiPrefix" type="System.Reflection.Metadata.Tests.MemoryBlockTests" method="Utf8NullTermintatedStringStartsWithAsciiPrefix" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.CompressedIntegerTests.CheckCompressedSignedIntegers" type="System.Reflection.Metadata.Tests.CompressedIntegerTests" method="CheckCompressedSignedIntegers" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.CompressedIntegerTests.DecompressUnsignedIntegersFromSpecExamples" type="System.Reflection.Metadata.Tests.CompressedIntegerTests" method="DecompressUnsignedIntegersFromSpecExamples" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.HandleTests.HandleConversionGivesCorrectKind" type="System.Reflection.Metadata.Tests.HandleTests" method="HandleConversionGivesCorrectKind" time="0,016" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.Bug17109" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="Bug17109" time="0,060" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MemoryBlockTests.DecoderIsUsedCorrectly" type="System.Reflection.Metadata.Tests.MemoryBlockTests" method="DecoderIsUsedCorrectly" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateInterfaceImplTable" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateInterfaceImplTable" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.MemberCollections_TypeMembers_LastTypeDef" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="MemberCollections_TypeMembers_LastTypeDef" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateModuleTableMod" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateModuleTableMod" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.CanCustomizeReaderUtf8Fallback" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="CanCustomizeReaderUtf8Fallback" time="0,013" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.AbstractMemoryBlockTests.FileStream" type="System.Reflection.Metadata.Tests.AbstractMemoryBlockTests" method="FileStream" time="0,004" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.TagToTokenTests.ValidateTagToTokenConversion" type="System.Reflection.Metadata.Tests.TagToTokenTests" method="ValidateTagToTokenConversion" time="0,016" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.CompressedIntegerTests.DecompressInvalidUnsignedIntegers" type="System.Reflection.Metadata.Tests.CompressedIntegerTests" method="DecompressInvalidUnsignedIntegers" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateInterfaceImplTableMod" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateInterfaceImplTableMod" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataTokensTests.CreateHandle" type="System.Reflection.Metadata.Tests.MetadataTokensTests" method="CreateHandle" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.StreamExtensionsTests.CopyTo2" type="System.Reflection.Metadata.Tests.StreamExtensionsTests" method="CopyTo2" time="0,008" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateFieldLayoutTable" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateFieldLayoutTable" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateCustomAttribute" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateCustomAttribute" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.HandleComparerTests.CompareTokens" type="System.Reflection.Metadata.Tests.HandleComparerTests" method="CompareTokens" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.PEReaderTests.OpenNativeImage" type="System.Reflection.Metadata.Tests.PEReaderTests" method="OpenNativeImage" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateMethodSematicsTable" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateMethodSematicsTable" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="System.Reflection.Metadata.Tests.MetadataReaderTests.ValidateExportedTypeTable" type="System.Reflection.Metadata.Tests.MetadataReaderTests" method="ValidateExportedTypeTable" time="0,011" result="Pass" />
+    </collection>
+  </assembly>
+  <assembly name="D:\Dev\corefx\bin\Release\System.Xml.XmlDocument.Tests\System.Xml.XmlDocument.Tests.dll" environment="32-bit .NET 4.0.30319.34014" test-framework="xUnit.net 1.9.2.1705" run-date="2014-11-15" run-time="17:25:53" total="449" passed="449" failed="0" skipped="0" time="0,215" errors="0">
+    <errors />
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ChildNodesTests.DocumentFragmentChildNodes" type="XmlDocumentTests.XmlNodeTests.ChildNodesTests" method="DocumentFragmentChildNodes" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.ReplaceTests.Replace1CharactersFromCdataNodeBeginning" type="XmlDocumentTests.XmlCharacterDataTests.ReplaceTests" method="Replace1CharactersFromCdataNodeBeginning" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NameTests.NameOfDocumentElement" type="XmlDocumentTests.XmlNodeTests.NameTests" method="NameOfDocumentElement" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.FirstChildTests.ElementNodeWithOneChild" type="XmlDocumentTests.XmlNodeTests.FirstChildTests" method="ElementNodeWithOneChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ParentNodeTests.NewlyCreatedTextNode" type="XmlDocumentTests.XmlNodeTests.ParentNodeTests" method="NewlyCreatedTextNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.FirstChildTests.ElementNodeWithOneChildDeleteItInsertTwoNewChildren" type="XmlDocumentTests.XmlNodeTests.FirstChildTests" method="ElementNodeWithOneChildDeleteItInsertTwoNewChildren" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlTextTests.SplitTextTests.SplitLongTextNodeAndNormalize" type="XmlDocumentTests.XmlTextTests.SplitTextTests" method="SplitLongTextNodeAndNormalize" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NamespaceURITests.XmlElementForEquals" type="XmlDocumentTests.XmlNodeTests.NamespaceURITests" method="XmlElementForEquals" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.FirstChildTests.ElementNodeWithOneChildDeleteItInsertNewChild" type="XmlDocumentTests.XmlNodeTests.FirstChildTests" method="ElementNodeWithOneChildDeleteItInsertNewChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LastChildTests.ElementWithNoChildTwoAttributes" type="XmlDocumentTests.XmlNodeTests.LastChildTests" method="ElementWithNoChildTwoAttributes" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetAttributeTests.RemoveFirstOfThreeAttributeAndGetIt" type="XmlDocumentTests.XmlElementTests.GetAttributeTests" method="RemoveFirstOfThreeAttributeAndGetIt" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.DeleteDataTests.DeleteCharsInMiddleOfCDataNode" type="XmlDocumentTests.XmlCharacterDataTests.DeleteDataTests" method="DeleteCharsInMiddleOfCDataNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertTests.TwoElementTests.Comment_SignificantWhitespace" type="XmlDocumentTests.XmlNodeTests.InsertTests.TwoElementTests" method="Comment_SignificantWhitespace" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NextSiblingTests.NewlyCreatedComment" type="XmlDocumentTests.XmlNodeTests.NextSiblingTests" method="NewlyCreatedComment" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NamespaceURITests.XmlDocumentEmptyString" type="XmlDocumentTests.XmlNodeTests.NamespaceURITests" method="XmlDocumentEmptyString" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.DataTests.GetDataFromCdataNode" type="XmlDocumentTests.XmlCharacterDataTests.DataTests" method="GetDataFromCdataNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetElementsByTagNameTests.RemoveOneElementFrom2SiblingElementsWithSameName" type="XmlDocumentTests.XmlElementTests.GetElementsByTagNameTests" method="RemoveOneElementFrom2SiblingElementsWithSameName" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.RemoveChildTests.CDATA_CDATA_CDATA" type="XmlDocumentTests.XmlNodeTests.RemoveChildTests" method="CDATA_CDATA_CDATA" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNamedNodeMapTests.RemoveNamedItemTests.WrongNameWrongNamespace" type="XmlDocumentTests.XmlNamedNodeMapTests.RemoveNamedItemTests" method="WrongNameWrongNamespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ChildNodesTests.GetChildNodesOfAnElementNodeWithNoChildren" type="XmlDocumentTests.XmlNodeTests.ChildNodesTests" method="GetChildNodesOfAnElementNodeWithNoChildren" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.ReplaceTests.ReplaceAllCharactersFromCdataNodeBeginning" type="XmlDocumentTests.XmlCharacterDataTests.ReplaceTests" method="ReplaceAllCharactersFromCdataNodeBeginning" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.FirstChildTests.FirstChildOfAttributeWithOnlyText" type="XmlDocumentTests.XmlNodeTests.FirstChildTests" method="FirstChildOfAttributeWithOnlyText" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.ReplaceTests.Replace0CharactersFromCdataNode" type="XmlDocumentTests.XmlCharacterDataTests.ReplaceTests" method="Replace0CharactersFromCdataNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.InsertChildBefore" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="InsertChildBefore" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertBeforeTests.InsertCommentNodeToDocumentFragment" type="XmlDocumentTests.XmlNodeTests.InsertBeforeTests" method="InsertCommentNodeToDocumentFragment" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetAttributeTests.SetAttributeThatExistsAndGetIt" type="XmlDocumentTests.XmlElementTests.GetAttributeTests" method="SetAttributeThatExistsAndGetIt" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.NewlyCreatedCDataNode" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="NewlyCreatedCDataNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ParentNodeTests.NewlyCreatedProcessingInstruction" type="XmlDocumentTests.XmlNodeTests.ParentNodeTests" method="NewlyCreatedProcessingInstruction" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NameTests.XmlDeclaration" type="XmlDocumentTests.XmlNodeTests.NameTests" method="XmlDeclaration" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.HasChildNodesTests.AddAnAttributeToAnElementWithNoChild" type="XmlDocumentTests.XmlNodeTests.HasChildNodesTests" method="AddAnAttributeToAnElementWithNoChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertBeforeTests.InsertChildNodeToItself" type="XmlDocumentTests.XmlNodeTests.InsertBeforeTests" method="InsertChildNodeToItself" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LastChildTests.NewlyCreatedDocumentFragment" type="XmlDocumentTests.XmlNodeTests.LastChildTests" method="NewlyCreatedDocumentFragment" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.NewlyCreatedDocumentFragment" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="NewlyCreatedDocumentFragment" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.GetElementsByTagNameTests.Attribute" type="XmlDocumentTests.XmlDocumentTests.GetElementsByTagNameTests" method="Attribute" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNamedNodeMapTests.RemoveNamedItemTests.RemoveMiddleItem" type="XmlDocumentTests.XmlNamedNodeMapTests.RemoveNamedItemTests" method="RemoveMiddleItem" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.OnTextNode" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="OnTextNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.RemoveChildTests.RemoveDocumentElement" type="XmlDocumentTests.XmlNodeTests.RemoveChildTests" method="RemoveDocumentElement" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ValueTests.TextNode" type="XmlDocumentTests.XmlNodeTests.ValueTests" method="TextNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NamespaceURITests.ReadXmlnsFromFile" type="XmlDocumentTests.XmlNodeTests.NamespaceURITests" method="ReadXmlnsFromFile" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LastChildTests.InsertChildAtLengthMinus1" type="XmlDocumentTests.XmlNodeTests.LastChildTests" method="InsertChildAtLengthMinus1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.HasChildNodesTests.CheckNoChildrenOnComment" type="XmlDocumentTests.XmlNodeTests.HasChildNodesTests" method="CheckNoChildrenOnComment" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNamedNodeMapTests.RemoveNamedItemTests.WrongNameExistingNamespace" type="XmlDocumentTests.XmlNamedNodeMapTests.RemoveNamedItemTests" method="WrongNameExistingNamespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.AppendDataTests.AppendNullToCDataNodeTest" type="XmlDocumentTests.XmlCharacterDataTests.AppendDataTests" method="AppendNullToCDataNodeTest" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertTests.TwoTextNodeTests.Text_SignificantWhitespace" type="XmlDocumentTests.XmlNodeTests.InsertTests.TwoTextNodeTests" method="Text_SignificantWhitespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.HasChildNodesTests.CloneAnElementWithChildNode" type="XmlDocumentTests.XmlNodeTests.HasChildNodesTests" method="CloneAnElementWithChildNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.GetElementsByTagNameTests.SanityCheck" type="XmlDocumentTests.XmlDocumentTests.GetElementsByTagNameTests" method="SanityCheck" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.CreateCDataSectionTests.CreateCDataTest1" type="XmlDocumentTests.XmlDocumentTests.CreateCDataSectionTests" method="CreateCDataTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ReplaceChildTests.ReplaceFirstChild" type="XmlDocumentTests.XmlNodeTests.ReplaceChildTests" method="ReplaceFirstChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.OnAllSiblings" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="OnAllSiblings" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NextSiblingTests.ElementOneChild" type="XmlDocumentTests.XmlNodeTests.NextSiblingTests" method="ElementOneChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.GetElementsByTagNameTests.LoadXmlTest2" type="XmlDocumentTests.XmlDocumentTests.GetElementsByTagNameTests" method="LoadXmlTest2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.GetElementsByTagNameTests.NullReference" type="XmlDocumentTests.XmlDocumentTests.GetElementsByTagNameTests" method="NullReference" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ChildNodesTests.GetChildNodesOfAnElementNodeWithAttributesButNoChildNodes" type="XmlDocumentTests.XmlNodeTests.ChildNodesTests" method="GetChildNodesOfAnElementNodeWithAttributesButNoChildNodes" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.FirstChildTests.FirstChildOfNewComment" type="XmlDocumentTests.XmlNodeTests.FirstChildTests" method="FirstChildOfNewComment" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.ReplaceChild" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="ReplaceChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.AppendChildTests.CallAppendChildOnPINode" type="XmlDocumentTests.XmlNodeTests.AppendChildTests" method="CallAppendChildOnPINode" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.HasChildNodesTests.AppendAnElementNOdeToAnElementNodeWithNoChild" type="XmlDocumentTests.XmlNodeTests.HasChildNodesTests" method="AppendAnElementNOdeToAnElementNodeWithNoChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NamespaceURITests.ChildWithDifferentNamespaceURI" type="XmlDocumentTests.XmlNodeTests.NamespaceURITests" method="ChildWithDifferentNamespaceURI" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.HasChildNodesTests.ElementWithAttributeAndNoChild" type="XmlDocumentTests.XmlNodeTests.HasChildNodesTests" method="ElementWithAttributeAndNoChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertBeforeTests.InsertCommentNodeToDocument" type="XmlDocumentTests.XmlNodeTests.InsertBeforeTests" method="InsertCommentNodeToDocument" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NormalizeTests.EmptyDocumentFragment" type="XmlDocumentTests.XmlNodeTests.NormalizeTests" method="EmptyDocumentFragment" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LastChildTests.InsertChildToElementWithNoNode" type="XmlDocumentTests.XmlNodeTests.LastChildTests" method="InsertChildToElementWithNoNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertBeforeTests.InsertAttributeNodeToDocumentNode" type="XmlDocumentTests.XmlNodeTests.InsertBeforeTests" method="InsertAttributeNodeToDocumentNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NodeTypeTests.ProcessingInstructionNodeTypeTest" type="XmlDocumentTests.XmlNodeTests.NodeTypeTests" method="ProcessingInstructionNodeTypeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NamespaceURITests.ChildWithDifferentNamespaceURIWithXmlns" type="XmlDocumentTests.XmlNodeTests.NamespaceURITests" method="ChildWithDifferentNamespaceURIWithXmlns" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.RemoveAttributeNodeTests.NormalWork" type="XmlDocumentTests.XmlElementTests.RemoveAttributeNodeTests" method="NormalWork" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.AppendChildTests.AppendAnElementFromOneTreeToAnother" type="XmlDocumentTests.XmlNodeTests.AppendChildTests" method="AppendAnElementFromOneTreeToAnother" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.DataTests.GetDataFromEmptyCdataNode" type="XmlDocumentTests.XmlCharacterDataTests.DataTests" method="GetDataFromEmptyCdataNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LastChildTests.AttributeWithOnlyText" type="XmlDocumentTests.XmlNodeTests.LastChildTests" method="AttributeWithOnlyText" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NodeTypeTests.TextNodeTypeTest" type="XmlDocumentTests.XmlNodeTests.NodeTypeTests" method="TextNodeTypeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertBeforeTests.InsertCDataNodeToDocumentNode" type="XmlDocumentTests.XmlNodeTests.InsertBeforeTests" method="InsertCDataNodeToDocumentNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNamedNodeMapTests.RemoveNamedItemTests.RemoveFirstItem" type="XmlDocumentTests.XmlNamedNodeMapTests.RemoveNamedItemTests" method="RemoveFirstItem" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNamedNodeMapTests.GetNameTests.EmptyElementCountTest" type="XmlDocumentTests.XmlNamedNodeMapTests.GetNameTests" method="EmptyElementCountTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertBeforeTests.InsertCDataToElementNode" type="XmlDocumentTests.XmlNodeTests.InsertBeforeTests" method="InsertCDataToElementNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.AppendChild" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="AppendChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LastChildTests.NewlyCreatedTextNode" type="XmlDocumentTests.XmlNodeTests.LastChildTests" method="NewlyCreatedTextNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.NodeInsertingTests.RemoveEventHandler" type="XmlDocumentTests.XmlDocumentTests.NodeInsertingTests" method="RemoveEventHandler" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNamedNodeMapTests.SetNamedItemTests.NamedItemDoesNotExist" type="XmlDocumentTests.XmlNamedNodeMapTests.SetNamedItemTests" method="NamedItemDoesNotExist" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ParentNodeTests.NewlyCreatedAttribute" type="XmlDocumentTests.XmlNodeTests.ParentNodeTests" method="NewlyCreatedAttribute" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.ImportNodeTests.ImportDocumentFragment" type="XmlDocumentTests.XmlDocumentTests.ImportNodeTests" method="ImportDocumentFragment" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NamespaceURITests.AllNodesForEmptyString" type="XmlDocumentTests.XmlNodeTests.NamespaceURITests" method="AllNodesForEmptyString" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.AttributesTests.GetAttributesOnDocumentFragment" type="XmlDocumentTests.XmlNodeTests.AttributesTests" method="GetAttributesOnDocumentFragment" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NextSiblingTests.AppendChild" type="XmlDocumentTests.XmlNodeTests.NextSiblingTests" method="AppendChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertTests.ThreeElementTests.Text_Comment_CDATA" type="XmlDocumentTests.XmlNodeTests.InsertTests.ThreeElementTests" method="Text_Comment_CDATA" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ChildNodesTests.XmlWithWhitespace" type="XmlDocumentTests.XmlNodeTests.ChildNodesTests" method="XmlWithWhitespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ReplaceChildTests.ReplaceAttributeChildWithElement" type="XmlDocumentTests.XmlNodeTests.ReplaceChildTests" method="ReplaceAttributeChildWithElement" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.HasChildNodesTests.CheckNoChildrenOnText" type="XmlDocumentTests.XmlNodeTests.HasChildNodesTests" method="CheckNoChildrenOnText" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertBeforeTests.InsertTextNodeToProcessingInstructionNode" type="XmlDocumentTests.XmlNodeTests.InsertBeforeTests" method="InsertTextNodeToProcessingInstructionNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNamedNodeMapTests.RemoveNamedItemTests.RemoveLastItem" type="XmlDocumentTests.XmlNamedNodeMapTests.RemoveNamedItemTests" method="RemoveLastItem" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.NodeInsertingTests.CreateElementAndModifyInnerText" type="XmlDocumentTests.XmlDocumentTests.NodeInsertingTests" method="CreateElementAndModifyInnerText" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ChildNodesTests.EmptyElementChildNodeCount" type="XmlDocumentTests.XmlNodeTests.ChildNodesTests" method="EmptyElementChildNodeCount" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetElementsByTagNameTests.GetByFirstAttributeNameOfElement" type="XmlDocumentTests.XmlElementTests.GetElementsByTagNameTests" method="GetByFirstAttributeNameOfElement" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.NodeRemovedTests.RemoveNode" type="XmlDocumentTests.XmlDocumentTests.NodeRemovedTests" method="RemoveNode" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ValueTests.CDataNodeNode" type="XmlDocumentTests.XmlNodeTests.ValueTests" method="CDataNodeNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNamedNodeMapTests.CountTests.AttributeCountTest" type="XmlDocumentTests.XmlNamedNodeMapTests.CountTests" method="AttributeCountTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.AttributesTests.GetAttributesOnCommentNode" type="XmlDocumentTests.XmlNodeTests.AttributesTests" method="GetAttributesOnCommentNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertBeforeTests.InsertDocFragmentToDocFragment" type="XmlDocumentTests.XmlNodeTests.InsertBeforeTests" method="InsertDocFragmentToDocFragment" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.CreateElementTests.ElementName" type="XmlDocumentTests.XmlDocumentTests.CreateElementTests" method="ElementName" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.CreateTextNodeTests.NodeTypeTest" type="XmlDocumentTests.XmlDocumentTests.CreateTextNodeTests" method="NodeTypeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.RemoveChildTests.SignificantWhitespace_Element_SignificantWhitespace" type="XmlDocumentTests.XmlNodeTests.RemoveChildTests" method="SignificantWhitespace_Element_SignificantWhitespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NextSiblingTests.NewlyCreatedProcessingInstruction" type="XmlDocumentTests.XmlNodeTests.NextSiblingTests" method="NewlyCreatedProcessingInstruction" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlImplementationTests.CreateDocumentTests.CreateDocument" type="XmlDocumentTests.XmlImplementationTests.CreateDocumentTests" method="CreateDocument" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ChildNodesTests.NestedChildren" type="XmlDocumentTests.XmlNodeTests.ChildNodesTests" method="NestedChildren" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NameTests.NameOfAllTypes" type="XmlDocumentTests.XmlNodeTests.NameTests" method="NameOfAllTypes" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetAttributeNodeTests.NonExistentAttribute" type="XmlDocumentTests.XmlElementTests.GetAttributeNodeTests" method="NonExistentAttribute" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ReplaceChildTests.ReplaceAttributeChildWithProcessingInstruction" type="XmlDocumentTests.XmlNodeTests.ReplaceChildTests" method="ReplaceAttributeChildWithProcessingInstruction" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.CreateProcessingInstruction.BasicCreate" type="XmlDocumentTests.XmlDocumentTests.CreateProcessingInstruction" method="BasicCreate" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNamedNodeMapTests.ItemTests.InvalidItemTest" type="XmlDocumentTests.XmlNamedNodeMapTests.ItemTests" method="InvalidItemTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetAttributeTests.WrongName" type="XmlDocumentTests.XmlElementTests.GetAttributeTests" method="WrongName" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ParentNodeTests.OnAttributeNode" type="XmlDocumentTests.XmlNodeTests.ParentNodeTests" method="OnAttributeNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NextSiblingTests.OnAllSiblings" type="XmlDocumentTests.XmlNodeTests.NextSiblingTests" method="OnAllSiblings" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertTests.ThreeElementTests.Text_Comment_SignificantWhitespace" type="XmlDocumentTests.XmlNodeTests.InsertTests.ThreeElementTests" method="Text_Comment_SignificantWhitespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.SetAttributeTests.AttributeAlreadyExists" type="XmlDocumentTests.XmlElementTests.SetAttributeTests" method="AttributeAlreadyExists" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ReplaceChildTests.DocumentElementNodeWithNewNode" type="XmlDocumentTests.XmlNodeTests.ReplaceChildTests" method="DocumentElementNodeWithNewNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetAttributeNodeTests.CloneAttributeNodeDeepTrue" type="XmlDocumentTests.XmlElementTests.GetAttributeNodeTests" method="CloneAttributeNodeDeepTrue" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertTests.TwoTextNodeTests.Whitespace_CDATA" type="XmlDocumentTests.XmlNodeTests.InsertTests.TwoTextNodeTests" method="Whitespace_CDATA" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.RemoveChildCheckSibling" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="RemoveChildCheckSibling" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.CreateAttributeTests.AttributeWithNoPrefixIsTheSameAsWithEmptyPrefix" type="XmlDocumentTests.XmlDocumentTests.CreateAttributeTests" method="AttributeWithNoPrefixIsTheSameAsWithEmptyPrefix" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlProcessingInstructionTests.DataTests.DataTest1" type="XmlDocumentTests.XmlProcessingInstructionTests.DataTests" method="DataTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.DeleteDataTests.DeleteAllCharsInCDataNode" type="XmlDocumentTests.XmlCharacterDataTests.DeleteDataTests" method="DeleteAllCharsInCDataNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NextSiblingTests.FirstChildNextSibling" type="XmlDocumentTests.XmlNodeTests.NextSiblingTests" method="FirstChildNextSibling" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LastChildTests.NewlyCreatedCDataNode" type="XmlDocumentTests.XmlNodeTests.LastChildTests" method="NewlyCreatedCDataNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ParentNodeTests.NewlyCreatedCDataNode" type="XmlDocumentTests.XmlNodeTests.ParentNodeTests" method="NewlyCreatedCDataNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNamedNodeMapTests.GetNamedItemTests.WrongNameWrongNamespace" type="XmlDocumentTests.XmlNamedNodeMapTests.GetNamedItemTests" method="WrongNameWrongNamespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.GetElementsByTagNameTests.EmptyDocument" type="XmlDocumentTests.XmlDocumentTests.GetElementsByTagNameTests" method="EmptyDocument" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NextSiblingTests.NewlyCreatedAttribute" type="XmlDocumentTests.XmlNodeTests.NextSiblingTests" method="NewlyCreatedAttribute" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlTextTests.SplitTextTests.SplitAtBeginningOfString" type="XmlDocumentTests.XmlTextTests.SplitTextTests" method="SplitAtBeginningOfString" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.DeleteDataTests.DeleteCharactersBeyondEndOfCDataNode" type="XmlDocumentTests.XmlCharacterDataTests.DeleteDataTests" method="DeleteCharactersBeyondEndOfCDataNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.ImportNodeTests.ImportElementDeepFalse" type="XmlDocumentTests.XmlDocumentTests.ImportNodeTests" method="ImportElementDeepFalse" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.OnCDataNode" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="OnCDataNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.CreateXmlDeclarationTests.CheckAllAttributesOnCloneTrue" type="XmlDocumentTests.XmlDocumentTests.CreateXmlDeclarationTests" method="CheckAllAttributesOnCloneTrue" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.RemoveChildTests.Whitespace_Text_Text_CDATA_SignificantWhitespace_SignificantWhitespace" type="XmlDocumentTests.XmlNodeTests.RemoveChildTests" method="Whitespace_Text_Text_CDATA_SignificantWhitespace_SignificantWhitespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.FirstChildTests.ElementNodeWithOneChildDeleteIt" type="XmlDocumentTests.XmlNodeTests.FirstChildTests" method="ElementNodeWithOneChildDeleteIt" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.HasChildNodesTests.RemoveAllChildrenAddAnElement" type="XmlDocumentTests.XmlNodeTests.HasChildNodesTests" method="RemoveAllChildrenAddAnElement" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.DeleteDataTests.DeleteCharactersStartBeyondEndOfCDataNode" type="XmlDocumentTests.XmlCharacterDataTests.DeleteDataTests" method="DeleteCharactersStartBeyondEndOfCDataNode" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.NodeChangedTests.RemoveNode" type="XmlDocumentTests.XmlDocumentTests.NodeChangedTests" method="RemoveNode" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertBeforeTests.InsertTextNodeToTextNode" type="XmlDocumentTests.XmlNodeTests.InsertBeforeTests" method="InsertTextNodeToTextNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNamedNodeMapTests.GetNamedItemTests.NormalWork" type="XmlDocumentTests.XmlNamedNodeMapTests.GetNamedItemTests" method="NormalWork" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.HasChildNodesTests.RemoveAllChildren" type="XmlDocumentTests.XmlNodeTests.HasChildNodesTests" method="RemoveAllChildren" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.FirstChildTests.ElementWithOneChildAnotherInsertedAtBeginning" type="XmlDocumentTests.XmlNodeTests.FirstChildTests" method="ElementWithOneChildAnotherInsertedAtBeginning" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetAttributeNodeTests.GetAttributeWhenValueIsEmpty" type="XmlDocumentTests.XmlElementTests.GetAttributeNodeTests" method="GetAttributeWhenValueIsEmpty" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.InsertChildAfter" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="InsertChildAfter" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlAttributeTests.OwnerDocumentTests.FromLoadedDocument" type="XmlDocumentTests.XmlAttributeTests.OwnerDocumentTests" method="FromLoadedDocument" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.SetAttributeTests.AttributeThatHasBeenDefined" type="XmlDocumentTests.XmlElementTests.SetAttributeTests" method="AttributeThatHasBeenDefined" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.FirstChildTests.ElementNodeWithTwoChildren" type="XmlDocumentTests.XmlNodeTests.FirstChildTests" method="ElementNodeWithTwoChildren" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ParentNodeTests.OnAttributeNodeChildTextNode" type="XmlDocumentTests.XmlNodeTests.ParentNodeTests" method="OnAttributeNodeChildTextNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ParentNodeTests.ParentOfFirstChild" type="XmlDocumentTests.XmlNodeTests.ParentNodeTests" method="ParentOfFirstChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ReplaceChildTests.ReplaceLastChild" type="XmlDocumentTests.XmlNodeTests.ReplaceChildTests" method="ReplaceLastChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNamedNodeMapTests.GetNamedItemTests.ExistingNameWrongNamespace" type="XmlDocumentTests.XmlNamedNodeMapTests.GetNamedItemTests" method="ExistingNameWrongNamespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NormalizeTests.EmptyDocument" type="XmlDocumentTests.XmlNodeTests.NormalizeTests" method="EmptyDocument" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ReplaceChildTests.ReplaceElementWithAttribute" type="XmlDocumentTests.XmlNodeTests.ReplaceChildTests" method="ReplaceElementWithAttribute" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.SupportsTests.AllRightNames" type="XmlDocumentTests.XmlNodeTests.SupportsTests" method="AllRightNames" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.AttributesTests.GetAttributesOnCDataNode" type="XmlDocumentTests.XmlNodeTests.AttributesTests" method="GetAttributesOnCDataNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NextSiblingTests.OnTextNode" type="XmlDocumentTests.XmlNodeTests.NextSiblingTests" method="OnTextNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LastChildTests.NewlyCreatedElement" type="XmlDocumentTests.XmlNodeTests.LastChildTests" method="NewlyCreatedElement" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ChildNodesTests.CDataChildNodeCount" type="XmlDocumentTests.XmlNodeTests.ChildNodesTests" method="CDataChildNodeCount" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlAttributeTests.OwnerDocumentTests.AttachingDetachingAttribute" type="XmlDocumentTests.XmlAttributeTests.OwnerDocumentTests" method="AttachingDetachingAttribute" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.OnAttributeNode" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="OnAttributeNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.AppendChildTests.CallAppendChildOnCommentNode" type="XmlDocumentTests.XmlNodeTests.AppendChildTests" method="CallAppendChildOnCommentNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LastChildTests.ElementWithNoChild" type="XmlDocumentTests.XmlNodeTests.LastChildTests" method="ElementWithNoChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.RemoveChildTests.Text_Element_Text" type="XmlDocumentTests.XmlNodeTests.RemoveChildTests" method="Text_Element_Text" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.OnTextNodeSplit" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="OnTextNodeSplit" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.CreateElementTests.SetAttributeAndInnerText" type="XmlDocumentTests.XmlDocumentTests.CreateElementTests" method="SetAttributeAndInnerText" time="0,007" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertBeforeTests.InsertNewNodeToElement" type="XmlDocumentTests.XmlNodeTests.InsertBeforeTests" method="InsertNewNodeToElement" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.AppendDataTests.AppendNullToTextNodeTest" type="XmlDocumentTests.XmlCharacterDataTests.AppendDataTests" method="AppendNullToTextNodeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.RemoveAttributeTests.WrongName" type="XmlDocumentTests.XmlElementTests.RemoveAttributeTests" method="WrongName" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ChildNodesTests.CountMixture1" type="XmlDocumentTests.XmlNodeTests.ChildNodesTests" method="CountMixture1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LocalNameTests.ElementWithNamespaces" type="XmlDocumentTests.XmlNodeTests.LocalNameTests" method="ElementWithNamespaces" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.AppendChildTests.AppendAttributeToAttribute" type="XmlDocumentTests.XmlNodeTests.AppendChildTests" method="AppendAttributeToAttribute" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlAttributeTests.OwnerDocumentTests.OwnerDocumentOnImportedTree" type="XmlDocumentTests.XmlAttributeTests.OwnerDocumentTests" method="OwnerDocumentOnImportedTree" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.FirstChildTests.FirstChildOfNewElement" type="XmlDocumentTests.XmlNodeTests.FirstChildTests" method="FirstChildOfNewElement" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.OnElementNode" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="OnElementNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.SetAttributeTests.AddingNewWithNamespace" type="XmlDocumentTests.XmlElementTests.SetAttributeTests" method="AddingNewWithNamespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.NodeInsertingTests.InsertNodeAfter" type="XmlDocumentTests.XmlDocumentTests.NodeInsertingTests" method="InsertNodeAfter" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.SetAttributeNodeTests.InsertAttributeInAnotherElement" type="XmlDocumentTests.XmlElementTests.SetAttributeNodeTests" method="InsertAttributeInAnotherElement" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.FirstChildTests.FirstChildOfNewDocumentFragment" type="XmlDocumentTests.XmlNodeTests.FirstChildTests" method="FirstChildOfNewDocumentFragment" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ReplaceChildTests.ReplaceAttributeChildWithAttribute" type="XmlDocumentTests.XmlNodeTests.ReplaceChildTests" method="ReplaceAttributeChildWithAttribute" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PrefixTests.ChangeQualifiedName" type="XmlDocumentTests.XmlNodeTests.PrefixTests" method="ChangeQualifiedName" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetAttributeNodeTests.CloneAttributeNodeDeepFalse" type="XmlDocumentTests.XmlElementTests.GetAttributeNodeTests" method="CloneAttributeNodeDeepFalse" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ChildNodesTests.TextNodeChildNodeCount" type="XmlDocumentTests.XmlNodeTests.ChildNodesTests" method="TextNodeChildNodeCount" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.CreateCDataSectionTests.CreateCDataTest5" type="XmlDocumentTests.XmlDocumentTests.CreateCDataSectionTests" method="CreateCDataTest5" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ParentNodeTests.NewlyCreatedComment" type="XmlDocumentTests.XmlNodeTests.ParentNodeTests" method="NewlyCreatedComment" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.ImportNodeTests.ImportAttributeDeepFalse" type="XmlDocumentTests.XmlDocumentTests.ImportNodeTests" method="ImportAttributeDeepFalse" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ReplaceChildTests.NodeWithNoChild" type="XmlDocumentTests.XmlNodeTests.ReplaceChildTests" method="NodeWithNoChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertTests.OneElementTests.SignificantWhitespace" type="XmlDocumentTests.XmlNodeTests.InsertTests.OneElementTests" method="SignificantWhitespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.CreateXmlDeclarationTests.InvalidEncoding" type="XmlDocumentTests.XmlDocumentTests.CreateXmlDeclarationTests" method="InvalidEncoding" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.OnDocumentElement" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="OnDocumentElement" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NormalizeTests.DocumentFragment" type="XmlDocumentTests.XmlNodeTests.NormalizeTests" method="DocumentFragment" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertBeforeTests.NodeWithNoChild" type="XmlDocumentTests.XmlNodeTests.InsertBeforeTests" method="NodeWithNoChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.ElementOneChild" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="ElementOneChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.AttributesTests.GetAttributesOnAnElementWithAttributes" type="XmlDocumentTests.XmlNodeTests.AttributesTests" method="GetAttributesOnAnElementWithAttributes" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertBeforeTests.InsertTextNodeToElementNode" type="XmlDocumentTests.XmlNodeTests.InsertBeforeTests" method="InsertTextNodeToElementNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ParentNodeTests.NewlyCreatedElement" type="XmlDocumentTests.XmlNodeTests.ParentNodeTests" method="NewlyCreatedElement" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.RemoveAttributeTests.GetElements" type="XmlDocumentTests.XmlElementTests.RemoveAttributeTests" method="GetElements" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.CreateAttributeTests.AttributeWithPrefix" type="XmlDocumentTests.XmlDocumentTests.CreateAttributeTests" method="AttributeWithPrefix" time="0,012" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetAttributeTests.GetOneAttribute" type="XmlDocumentTests.XmlElementTests.GetAttributeTests" method="GetOneAttribute" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.FirstChildTests.ElementNodeWithOneChildDeleteItInsertTwoNewChildrenDeleteAll" type="XmlDocumentTests.XmlNodeTests.FirstChildTests" method="ElementNodeWithOneChildDeleteItInsertTwoNewChildrenDeleteAll" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.InsertDataTests.InsertDataAtBeginningOfCdataNode" type="XmlDocumentTests.XmlCharacterDataTests.InsertDataTests" method="InsertDataAtBeginningOfCdataNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.HasChildNodesTests.CheckNoChildrenOnCData" type="XmlDocumentTests.XmlNodeTests.HasChildNodesTests" method="CheckNoChildrenOnCData" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetElementsByTagNameTests.GetElementWhenBelongsToNamespace" type="XmlDocumentTests.XmlElementTests.GetElementsByTagNameTests" method="GetElementWhenBelongsToNamespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.NewlyCreatedProcessingInstruction" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="NewlyCreatedProcessingInstruction" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.LengthTests.CreateEmptyCdata" type="XmlDocumentTests.XmlCharacterDataTests.LengthTests" method="CreateEmptyCdata" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NodeTypeTests.DocumentNodeTypeTest" type="XmlDocumentTests.XmlNodeTests.NodeTypeTests" method="DocumentNodeTypeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeListTests.ItemTests.ItemTest1" type="XmlDocumentTests.XmlNodeListTests.ItemTests" method="ItemTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LastChildTests.ReplaceOnlyChildOfNode" type="XmlDocumentTests.XmlNodeTests.LastChildTests" method="ReplaceOnlyChildOfNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ChildNodesTests.CommentChildNodeCount" type="XmlDocumentTests.XmlNodeTests.ChildNodesTests" method="CommentChildNodeCount" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.FirstChildTests.ElementWithNoChild" type="XmlDocumentTests.XmlNodeTests.FirstChildTests" method="ElementWithNoChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.NodeChangedTests.RemoveEventHandler" type="XmlDocumentTests.XmlDocumentTests.NodeChangedTests" method="RemoveEventHandler" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.AppendChildTests.AppendElementToElementWithChildren" type="XmlDocumentTests.XmlNodeTests.AppendChildTests" method="AppendElementToElementWithChildren" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetAttributeTests.RemoveAnAttributeAndGetIt" type="XmlDocumentTests.XmlElementTests.GetAttributeTests" method="RemoveAnAttributeAndGetIt" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.NewlyCreatedElement" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="NewlyCreatedElement" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LocalNameTests.ElementWithPrefix" type="XmlDocumentTests.XmlNodeTests.LocalNameTests" method="ElementWithPrefix" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LastChildTests.DeleteOnlyChildInsertNewNode" type="XmlDocumentTests.XmlNodeTests.LastChildTests" method="DeleteOnlyChildInsertNewNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetElementsByTagNameTests.GetElements" type="XmlDocumentTests.XmlElementTests.GetElementsByTagNameTests" method="GetElements" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.DeleteDataTests.DeleteCharactersBeyondEndOfCDataNodeWithLargeNumber" type="XmlDocumentTests.XmlCharacterDataTests.DeleteDataTests" method="DeleteCharactersBeyondEndOfCDataNodeWithLargeNumber" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.SetAttributeNodeTests.ElementWithSameAttribute" type="XmlDocumentTests.XmlElementTests.SetAttributeNodeTests" method="ElementWithSameAttribute" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetAttributeNodeTests.GetAttributeWhenValueIsNotEmpty" type="XmlDocumentTests.XmlElementTests.GetAttributeNodeTests" method="GetAttributeWhenValueIsNotEmpty" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NextSiblingTests.OnTextNodeSplit" type="XmlDocumentTests.XmlNodeTests.NextSiblingTests" method="OnTextNodeSplit" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NextSiblingTests.OnCDataNode" type="XmlDocumentTests.XmlNodeTests.NextSiblingTests" method="OnCDataNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.RemoveChildTests.Text_Comment_SignificantWhitespace" type="XmlDocumentTests.XmlNodeTests.RemoveChildTests" method="Text_Comment_SignificantWhitespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.CreateElementTests.NamespaceWithLocalName" type="XmlDocumentTests.XmlDocumentTests.CreateElementTests" method="NamespaceWithLocalName" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.SupportsTests.WrongFeature" type="XmlDocumentTests.XmlNodeTests.SupportsTests" method="WrongFeature" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NextSiblingTests.NewlyCreatedElement" type="XmlDocumentTests.XmlNodeTests.NextSiblingTests" method="NewlyCreatedElement" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LastChildTests.NewlyCreatedAttribute" type="XmlDocumentTests.XmlNodeTests.LastChildTests" method="NewlyCreatedAttribute" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertTests.ThreeElementTests.Whitespace_Comment_Text" type="XmlDocumentTests.XmlNodeTests.InsertTests.ThreeElementTests" method="Whitespace_Comment_Text" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ChildNodesTests.ProcessingInstructionChildNodeCount" type="XmlDocumentTests.XmlNodeTests.ChildNodesTests" method="ProcessingInstructionChildNodeCount" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.HasChildNodesTests.CheckNoChildrenOnPI" type="XmlDocumentTests.XmlNodeTests.HasChildNodesTests" method="CheckNoChildrenOnPI" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.RemoveChildTests.CDATA_Element_CDATA" type="XmlDocumentTests.XmlNodeTests.RemoveChildTests" method="CDATA_Element_CDATA" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertTests.TwoElementTests.Text_Element" type="XmlDocumentTests.XmlNodeTests.InsertTests.TwoElementTests" method="Text_Element" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.InsertDataTests.InsertDataAtMiddleOfCdataNode" type="XmlDocumentTests.XmlCharacterDataTests.InsertDataTests" method="InsertDataAtMiddleOfCdataNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NextSiblingTests.OnDocumentElement" type="XmlDocumentTests.XmlNodeTests.NextSiblingTests" method="OnDocumentElement" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.CreateElementTests.EmptyName" type="XmlDocumentTests.XmlDocumentTests.CreateElementTests" method="EmptyName" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNamedNodeMapTests.RemoveNamedItemTests.ExistingNameWrongNamespace" type="XmlDocumentTests.XmlNamedNodeMapTests.RemoveNamedItemTests" method="ExistingNameWrongNamespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.RemoveAttributeNodeTests.WrongName" type="XmlDocumentTests.XmlElementTests.RemoveAttributeNodeTests" method="WrongName" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.RemoveChildTests.RepeatedRemoveInsert" type="XmlDocumentTests.XmlNodeTests.RemoveChildTests" method="RepeatedRemoveInsert" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LastChildTests.NewlyCreatedComment" type="XmlDocumentTests.XmlNodeTests.LastChildTests" method="NewlyCreatedComment" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetAttributeTests.WrongNamespace" type="XmlDocumentTests.XmlElementTests.GetAttributeTests" method="WrongNamespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ChildNodesTests.EmptyXmlDocument" type="XmlDocumentTests.XmlNodeTests.ChildNodesTests" method="EmptyXmlDocument" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetElementsByTagNameTests.GetByTagnameEqualsAsterisk" type="XmlDocumentTests.XmlElementTests.GetElementsByTagNameTests" method="GetByTagnameEqualsAsterisk" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LastChildTests.ElementWithMoreThanOneChild" type="XmlDocumentTests.XmlNodeTests.LastChildTests" method="ElementWithMoreThanOneChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.CreateDocumentFragment.CheckNodeType" type="XmlDocumentTests.XmlDocumentTests.CreateDocumentFragment" method="CheckNodeType" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.DeleteDataTests.DeleteOneCharacterFromBeginningOfCDataNode" type="XmlDocumentTests.XmlCharacterDataTests.DeleteDataTests" method="DeleteOneCharacterFromBeginningOfCDataNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.HasAttributeTests.NonExistingAttribute" type="XmlDocumentTests.XmlElementTests.HasAttributeTests" method="NonExistingAttribute" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.RemoveAttributeTests.WrongNamespace" type="XmlDocumentTests.XmlElementTests.RemoveAttributeTests" method="WrongNamespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertTests.OneElementTests.CDATA" type="XmlDocumentTests.XmlNodeTests.InsertTests.OneElementTests" method="CDATA" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.HasChildNodesTests.DocumentWithOnlyDocumentElement" type="XmlDocumentTests.XmlNodeTests.HasChildNodesTests" method="DocumentWithOnlyDocumentElement" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.FirstChildTests.ElementWithNoChildTwoAttributes" type="XmlDocumentTests.XmlNodeTests.FirstChildTests" method="ElementWithNoChildTwoAttributes" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.CreateXmlDeclarationTests.CheckAllAttributesOnCloneFalse" type="XmlDocumentTests.XmlDocumentTests.CreateXmlDeclarationTests" method="CheckAllAttributesOnCloneFalse" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.NewlyCreatedAttribute" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="NewlyCreatedAttribute" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetAttributeNodeTests.CreateAttributeNode" type="XmlDocumentTests.XmlElementTests.GetAttributeNodeTests" method="CreateAttributeNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.SetAttributeTests.ElementWithNoAttributes" type="XmlDocumentTests.XmlElementTests.SetAttributeTests" method="ElementWithNoAttributes" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.GetElementsByTagNameTests.WrongLocalName" type="XmlDocumentTests.XmlDocumentTests.GetElementsByTagNameTests" method="WrongLocalName" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.DeleteDataTests.DeleteCharactersStartNegativeOfCDataNode" type="XmlDocumentTests.XmlCharacterDataTests.DeleteDataTests" method="DeleteCharactersStartNegativeOfCDataNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NextSiblingTests.NewlyCreatedTextNode" type="XmlDocumentTests.XmlNodeTests.NextSiblingTests" method="NewlyCreatedTextNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertTests.TwoElementTests.Comment_Text" type="XmlDocumentTests.XmlNodeTests.InsertTests.TwoElementTests" method="Comment_Text" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertBeforeTests.NodeWithOneChild" type="XmlDocumentTests.XmlNodeTests.InsertBeforeTests" method="NodeWithOneChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NextSiblingTests.OnAttributeNodeWithChildren" type="XmlDocumentTests.XmlNodeTests.NextSiblingTests" method="OnAttributeNodeWithChildren" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ValueTests.NonEmptyAttribute" type="XmlDocumentTests.XmlNodeTests.ValueTests" method="NonEmptyAttribute" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NameTests.ElementWithExplicitlyStatedNamespace" type="XmlDocumentTests.XmlNodeTests.NameTests" method="ElementWithExplicitlyStatedNamespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.HasAttributeTests.WrongNamespace" type="XmlDocumentTests.XmlElementTests.HasAttributeTests" method="WrongNamespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NodeTypeTests.AttributeNodeTypeTest" type="XmlDocumentTests.XmlNodeTests.NodeTypeTests" method="AttributeNodeTypeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.FirstChildTests.ElementNodeWithTwoChildrenDeleteFirst" type="XmlDocumentTests.XmlNodeTests.FirstChildTests" method="ElementNodeWithTwoChildrenDeleteFirst" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.SupportsTests.WrongVersions" type="XmlDocumentTests.XmlNodeTests.SupportsTests" method="WrongVersions" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.RemoveChildTests.Whitespace_Whitespace_Whitespace" type="XmlDocumentTests.XmlNodeTests.RemoveChildTests" method="Whitespace_Whitespace_Whitespace" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.CreateAttributeTests.CreateBasicAttributeTest" type="XmlDocumentTests.XmlDocumentTests.CreateAttributeTests" method="CreateBasicAttributeTest" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.CreateXmlDeclarationTests.WrongXmlVersion" type="XmlDocumentTests.XmlDocumentTests.CreateXmlDeclarationTests" method="WrongXmlVersion" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LastChildTests.NewlyCreatedProcessingInstruction" type="XmlDocumentTests.XmlNodeTests.LastChildTests" method="NewlyCreatedProcessingInstruction" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlAttributeTests.OwnerDocumentTests.CheckOwnerOfDocumentNode" type="XmlDocumentTests.XmlAttributeTests.OwnerDocumentTests" method="CheckOwnerOfDocumentNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertTests.TwoElementTests.CDATA_Element" type="XmlDocumentTests.XmlNodeTests.InsertTests.TwoElementTests" method="CDATA_Element" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.SetAttributeTests.ElementWithAttributes" type="XmlDocumentTests.XmlElementTests.SetAttributeTests" method="ElementWithAttributes" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.HasChildNodesTests.InsertAChildToDocumentFragment" type="XmlDocumentTests.XmlNodeTests.HasChildNodesTests" method="InsertAChildToDocumentFragment" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.ReplaceTests.ReplaceCharactersFromCdataNodeWhenStringIsShorter" type="XmlDocumentTests.XmlCharacterDataTests.ReplaceTests" method="ReplaceCharactersFromCdataNodeWhenStringIsShorter" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.ImportNodeTests.ImportSignificantWhitespace" type="XmlDocumentTests.XmlDocumentTests.ImportNodeTests" method="ImportSignificantWhitespace" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.AppendDataTests.AppendNullToCommentNodeTest" type="XmlDocumentTests.XmlCharacterDataTests.AppendDataTests" method="AppendNullToCommentNodeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LastChildTests.DeleteOnlyChild" type="XmlDocumentTests.XmlNodeTests.LastChildTests" method="DeleteOnlyChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertTests.ThreeElementTests.CDATA_Element_CDATA" type="XmlDocumentTests.XmlNodeTests.InsertTests.ThreeElementTests" method="CDATA_Element_CDATA" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetAttributeNodeTests.EmptyString" type="XmlDocumentTests.XmlElementTests.GetAttributeNodeTests" method="EmptyString" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.FirstChildTests.FirstChildOfNewDocumentFragmentWithChildren" type="XmlDocumentTests.XmlNodeTests.FirstChildTests" method="FirstChildOfNewDocumentFragmentWithChildren" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.GetElementsByTagNameTests.LoadXmlTest1" type="XmlDocumentTests.XmlDocumentTests.GetElementsByTagNameTests" method="LoadXmlTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.HasAttributeTests.ExistingAttribute" type="XmlDocumentTests.XmlElementTests.HasAttributeTests" method="ExistingAttribute" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.NewlyCreatedComment" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="NewlyCreatedComment" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.AppendDataTests.AppendDataToAnEmptyCdataNode" type="XmlDocumentTests.XmlCharacterDataTests.AppendDataTests" method="AppendDataToAnEmptyCdataNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.SetAttributeTests.ValueWithNamespace" type="XmlDocumentTests.XmlElementTests.SetAttributeTests" method="ValueWithNamespace" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNamedNodeMapTests.RemoveNamedItemTests.NamedItemDoesNotExist" type="XmlDocumentTests.XmlNamedNodeMapTests.RemoveNamedItemTests" method="NamedItemDoesNotExist" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NamespaceURITests.ChangeXmlnsPropertyAfterLoading" type="XmlDocumentTests.XmlNodeTests.NamespaceURITests" method="ChangeXmlnsPropertyAfterLoading" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.NodeInsertedTests.RemoveEventHandler" type="XmlDocumentTests.XmlDocumentTests.NodeInsertedTests" method="RemoveEventHandler" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.HasAttributeTests.ExistingNamespace" type="XmlDocumentTests.XmlElementTests.HasAttributeTests" method="ExistingNamespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.RemoveChildTests.SignificantWhitespace_SignificantWhitespace_SignificantWhitespace" type="XmlDocumentTests.XmlNodeTests.RemoveChildTests" method="SignificantWhitespace_SignificantWhitespace_SignificantWhitespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ValueTests.RemoveCommentNode" type="XmlDocumentTests.XmlNodeTests.ValueTests" method="RemoveCommentNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.RemoveAttributeTests.RemoveAttribute" type="XmlDocumentTests.XmlElementTests.RemoveAttributeTests" method="RemoveAttribute" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.RemoveChildTests.FromNodesThatCannotContainChildren" type="XmlDocumentTests.XmlNodeTests.RemoveChildTests" method="FromNodesThatCannotContainChildren" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetElementsByTagNameTests.GetElementsWhenNoneExist" type="XmlDocumentTests.XmlElementTests.GetElementsByTagNameTests" method="GetElementsWhenNoneExist" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LastChildTests.ElementNodeWithOneChildAndOneElement" type="XmlDocumentTests.XmlNodeTests.LastChildTests" method="ElementNodeWithOneChildAndOneElement" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertBeforeTests.RemoveAndInsert" type="XmlDocumentTests.XmlNodeTests.InsertBeforeTests" method="RemoveAndInsert" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NextSiblingTests.InsertChildAfter" type="XmlDocumentTests.XmlNodeTests.NextSiblingTests" method="InsertChildAfter" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.FirstChildTests.FirstChildOfNewTextNode" type="XmlDocumentTests.XmlNodeTests.FirstChildTests" method="FirstChildOfNewTextNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.AppendDataTests.AppendDataToACdataNodeWithSomeContent" type="XmlDocumentTests.XmlCharacterDataTests.AppendDataTests" method="AppendDataToACdataNodeWithSomeContent" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertTests.TwoTextNodeTests.SignificantWhitespace_SignificantWhitespace" type="XmlDocumentTests.XmlNodeTests.InsertTests.TwoTextNodeTests" method="SignificantWhitespace_SignificantWhitespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ReplaceChildTests.DifferentTrees" type="XmlDocumentTests.XmlNodeTests.ReplaceChildTests" method="DifferentTrees" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.LengthTests.LengthOfCdata" type="XmlDocumentTests.XmlCharacterDataTests.LengthTests" method="LengthOfCdata" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNamedNodeMapTests.GetNamedItemTests.WrongNameExistingNamespace" type="XmlDocumentTests.XmlNamedNodeMapTests.GetNamedItemTests" method="WrongNameExistingNamespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.NewlyCreatedTextNode" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="NewlyCreatedTextNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ChildNodesTests.ChildNodeOfAttribute" type="XmlDocumentTests.XmlNodeTests.ChildNodesTests" method="ChildNodeOfAttribute" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.HasAttributeTests.NonExistingNamespace" type="XmlDocumentTests.XmlElementTests.HasAttributeTests" method="NonExistingNamespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.CreateCDataSectionTests.CreateCDataTest2" type="XmlDocumentTests.XmlDocumentTests.CreateCDataSectionTests" method="CreateCDataTest2" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.FirstChildTests.FirstChildOfNewAttribute" type="XmlDocumentTests.XmlNodeTests.FirstChildTests" method="FirstChildOfNewAttribute" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.NodeInsertedTests.InsertNodeAfter" type="XmlDocumentTests.XmlDocumentTests.NodeInsertedTests" method="InsertNodeAfter" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.AttributesTests.GetAttributesOnTextNode" type="XmlDocumentTests.XmlNodeTests.AttributesTests" method="GetAttributesOnTextNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertTests.TwoTextNodeTests.Text_Text" type="XmlDocumentTests.XmlNodeTests.InsertTests.TwoTextNodeTests" method="Text_Text" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.OnAttributeNodeWithChildren" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="OnAttributeNodeWithChildren" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.FirstChildTests.ElementNodeWithOneChildOneAttribute" type="XmlDocumentTests.XmlNodeTests.FirstChildTests" method="ElementNodeWithOneChildOneAttribute" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ChildNodesTests.EmptyAttributeChildNodeCount" type="XmlDocumentTests.XmlNodeTests.ChildNodesTests" method="EmptyAttributeChildNodeCount" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.CreateCDataSectionTests.CreateCDataTest3" type="XmlDocumentTests.XmlDocumentTests.CreateCDataSectionTests" method="CreateCDataTest3" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.InsertDataTests.InsertDataBeyondEndOfEmptyCdataNode" type="XmlDocumentTests.XmlCharacterDataTests.InsertDataTests" method="InsertDataBeyondEndOfEmptyCdataNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetAttributeNodeTests.GetRemovedAttribute" type="XmlDocumentTests.XmlElementTests.GetAttributeNodeTests" method="GetRemovedAttribute" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.FirstChildTests.FirstChildOfNewProcessingInstruction" type="XmlDocumentTests.XmlNodeTests.FirstChildTests" method="FirstChildOfNewProcessingInstruction" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.CreateXmlDeclarationTests.InvalidStandalone2" type="XmlDocumentTests.XmlDocumentTests.CreateXmlDeclarationTests" method="InvalidStandalone2" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.DataTests.SetDataFromEmptyCdataNode" type="XmlDocumentTests.XmlCharacterDataTests.DataTests" method="SetDataFromEmptyCdataNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertTests.TwoTextNodeTests.Whitespace_Whitespace" type="XmlDocumentTests.XmlNodeTests.InsertTests.TwoTextNodeTests" method="Whitespace_Whitespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertTests.ThreeElementTests.Whitespace_Element_Whitespace" type="XmlDocumentTests.XmlNodeTests.InsertTests.ThreeElementTests" method="Whitespace_Element_Whitespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetElementsByTagNameTests.GetCaseSensitiveElements" type="XmlDocumentTests.XmlElementTests.GetElementsByTagNameTests" method="GetCaseSensitiveElements" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.FirstChildTests.FirstChildOfNewCDataSection" type="XmlDocumentTests.XmlNodeTests.FirstChildTests" method="FirstChildOfNewCDataSection" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.CreateElementTests.LongElementName" type="XmlDocumentTests.XmlDocumentTests.CreateElementTests" method="LongElementName" time="0,012" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ChildNodesTests.ListWithMultipleKinds" type="XmlDocumentTests.XmlNodeTests.ChildNodesTests" method="ListWithMultipleKinds" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LastChildTests.DeleteOnlyChildAddTwoChildrenDeleteBoth" type="XmlDocumentTests.XmlNodeTests.LastChildTests" method="DeleteOnlyChildAddTwoChildrenDeleteBoth" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LastChildTests.ReplaceChild" type="XmlDocumentTests.XmlNodeTests.LastChildTests" method="ReplaceChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.DataTests.SetDataFromCdataNode" type="XmlDocumentTests.XmlCharacterDataTests.DataTests" method="SetDataFromCdataNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNamedNodeMapTests.ItemTests.ValidItemTest" type="XmlDocumentTests.XmlNamedNodeMapTests.ItemTests" method="ValidItemTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertTests.TwoElementTests.Whitespace_Element" type="XmlDocumentTests.XmlNodeTests.InsertTests.TwoElementTests" method="Whitespace_Element" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ParentNodeTests.OnDocumentElement" type="XmlDocumentTests.XmlNodeTests.ParentNodeTests" method="OnDocumentElement" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.ReplaceTests.Replace4CharactersFromCdataNode" type="XmlDocumentTests.XmlCharacterDataTests.ReplaceTests" method="Replace4CharactersFromCdataNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.LengthTests.LengthOfCdataAfterDelete" type="XmlDocumentTests.XmlCharacterDataTests.LengthTests" method="LengthOfCdataAfterDelete" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.CreateCDataSectionTests.CreateCDataTest4" type="XmlDocumentTests.XmlDocumentTests.CreateCDataSectionTests" method="CreateCDataTest4" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertTests.ThreeElementTests.SignificantWhitespace_Element_SignificantWhitespace" type="XmlDocumentTests.XmlNodeTests.InsertTests.ThreeElementTests" method="SignificantWhitespace_Element_SignificantWhitespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.RemoveChildTests.IterativelyRemoveAllChildNodes" type="XmlDocumentTests.XmlNodeTests.RemoveChildTests" method="IterativelyRemoveAllChildNodes" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.NodeRemovingTests.RemoveEventHandler" type="XmlDocumentTests.XmlDocumentTests.NodeRemovingTests" method="RemoveEventHandler" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.CreateXmlDeclarationTests.CheckAllAttributes" type="XmlDocumentTests.XmlDocumentTests.CreateXmlDeclarationTests" method="CheckAllAttributes" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NextSiblingTests.ReplaceChild" type="XmlDocumentTests.XmlNodeTests.NextSiblingTests" method="ReplaceChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PrefixTests.EmptyWork" type="XmlDocumentTests.XmlNodeTests.PrefixTests" method="EmptyWork" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertBeforeTests.InsertCDataNodeToAnAttributeNode" type="XmlDocumentTests.XmlNodeTests.InsertBeforeTests" method="InsertCDataNodeToAnAttributeNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.SetAttributeNodeTests.ElementWithAttributes" type="XmlDocumentTests.XmlElementTests.SetAttributeNodeTests" method="ElementWithAttributes" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlTextTests.SplitTextTests.TextWithWhiteSpace" type="XmlDocumentTests.XmlTextTests.SplitTextTests" method="TextWithWhiteSpace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertBeforeTests.InsertCDataNodeToDocumentFragment" type="XmlDocumentTests.XmlNodeTests.InsertBeforeTests" method="InsertCDataNodeToDocumentFragment" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NodeTypeTests.CDataNodeTypeTest" type="XmlDocumentTests.XmlNodeTests.NodeTypeTests" method="CDataNodeTypeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNamedNodeMapTests.CountTests.EmptyElementCountTest" type="XmlDocumentTests.XmlNamedNodeMapTests.CountTests" method="EmptyElementCountTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.OnCommentNode" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="OnCommentNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NormalizeTests.NormalWork" type="XmlDocumentTests.XmlNodeTests.NormalizeTests" method="NormalWork" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ChildNodesTests.ElementNodeWithChildButNoAttribute" type="XmlDocumentTests.XmlNodeTests.ChildNodesTests" method="ElementNodeWithChildButNoAttribute" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.NodeChangingTests.RemoveEventHandler" type="XmlDocumentTests.XmlDocumentTests.NodeChangingTests" method="RemoveEventHandler" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.SetAttributeTests.NoNamespaceWhenAttributeByThatNameWithNamespaceExists" type="XmlDocumentTests.XmlElementTests.SetAttributeTests" method="NoNamespaceWhenAttributeByThatNameWithNamespaceExists" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.CloneNodeTests.CloneComplexDocumentFalse" type="XmlDocumentTests.XmlNodeTests.CloneNodeTests" method="CloneComplexDocumentFalse" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.CreateCommentTests.CreateEmptyComment" type="XmlDocumentTests.XmlDocumentTests.CreateCommentTests" method="CreateEmptyComment" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ReplaceChildTests.ReplaceAttributeChildWithText" type="XmlDocumentTests.XmlNodeTests.ReplaceChildTests" method="ReplaceAttributeChildWithText" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertTests.TwoTextNodeTests.CDATA_Text" type="XmlDocumentTests.XmlNodeTests.InsertTests.TwoTextNodeTests" method="CDATA_Text" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.LengthTests.CreateCdata" type="XmlDocumentTests.XmlCharacterDataTests.LengthTests" method="CreateCdata" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NormalizeTests.TwoCalls" type="XmlDocumentTests.XmlNodeTests.NormalizeTests" method="TwoCalls" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertBeforeTests.InsertTextNodeToCommentNode" type="XmlDocumentTests.XmlNodeTests.InsertBeforeTests" method="InsertTextNodeToCommentNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ReplaceChildTests.NotNodeChild" type="XmlDocumentTests.XmlNodeTests.ReplaceChildTests" method="NotNodeChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NextSiblingTests.SiblingOfLastChild" type="XmlDocumentTests.XmlNodeTests.NextSiblingTests" method="SiblingOfLastChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.OnDocumentFragment" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="OnDocumentFragment" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.CloneNodeTests.CloneComplexDocumentTrueAndManipulate" type="XmlDocumentTests.XmlNodeTests.CloneNodeTests" method="CloneComplexDocumentTrueAndManipulate" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.DeleteDataTests.DeleteLastCharacterOfCDataNode" type="XmlDocumentTests.XmlCharacterDataTests.DeleteDataTests" method="DeleteLastCharacterOfCDataNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.RemoveChildTests.Whitespace_Element_Whitespace" type="XmlDocumentTests.XmlNodeTests.RemoveChildTests" method="Whitespace_Element_Whitespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.HasChildNodesTests.AttributeWithEmptyString" type="XmlDocumentTests.XmlNodeTests.HasChildNodesTests" method="AttributeWithEmptyString" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.RemoveChildTests.Text_Comment_CDATA" type="XmlDocumentTests.XmlNodeTests.RemoveChildTests" method="Text_Comment_CDATA" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.FirstChildNextSibling" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="FirstChildNextSibling" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertBeforeTests.InsertTextNodeToDocumentFragment" type="XmlDocumentTests.XmlNodeTests.InsertBeforeTests" method="InsertTextNodeToDocumentFragment" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.HasChildNodesTests.AttributeWithStringValue" type="XmlDocumentTests.XmlNodeTests.HasChildNodesTests" method="AttributeWithStringValue" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.InsertDataTests.InsertDataInEmptyCdataNode" type="XmlDocumentTests.XmlCharacterDataTests.InsertDataTests" method="InsertDataInEmptyCdataNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.GetElementsByTagNameTests.NameIsQualified" type="XmlDocumentTests.XmlDocumentTests.GetElementsByTagNameTests" method="NameIsQualified" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LastChildTests.DeleteOnlyChildAddTwoChildren" type="XmlDocumentTests.XmlNodeTests.LastChildTests" method="DeleteOnlyChildAddTwoChildren" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NodeTypeTests.ElementNodeTypeTest" type="XmlDocumentTests.XmlNodeTests.NodeTypeTests" method="ElementNodeTypeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NextSiblingTests.RemoveChildCheckSibling" type="XmlDocumentTests.XmlNodeTests.NextSiblingTests" method="RemoveChildCheckSibling" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.GetElementsByTagNameTests.MissingName" type="XmlDocumentTests.XmlDocumentTests.GetElementsByTagNameTests" method="MissingName" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.NodeRemovedTests.RemoveEventHandler" type="XmlDocumentTests.XmlDocumentTests.NodeRemovedTests" method="RemoveEventHandler" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PrefixTests.SetForAllNodes" type="XmlDocumentTests.XmlNodeTests.PrefixTests" method="SetForAllNodes" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.SetAttributeTests.AttributeThatHasBeenDefinedWithMoreThanTwoAttributes" type="XmlDocumentTests.XmlElementTests.SetAttributeTests" method="AttributeThatHasBeenDefinedWithMoreThanTwoAttributes" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ChildNodesTests.GetChildNodesOfAnElementNodeWithAttributesAndChildren" type="XmlDocumentTests.XmlNodeTests.ChildNodesTests" method="GetChildNodesOfAnElementNodeWithAttributesAndChildren" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetAttributeNodeTests.ElementWithoutAttributes" type="XmlDocumentTests.XmlElementTests.GetAttributeNodeTests" method="ElementWithoutAttributes" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.CreateElementTests.NullName" type="XmlDocumentTests.XmlDocumentTests.CreateElementTests" method="NullName" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ChildNodesTests.ReplacingNodeDoesNotChangeChildNodesList" type="XmlDocumentTests.XmlNodeTests.ChildNodesTests" method="ReplacingNodeDoesNotChangeChildNodesList" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.GetElementsByTagNameTests.MissingElement" type="XmlDocumentTests.XmlDocumentTests.GetElementsByTagNameTests" method="MissingElement" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.RemoveChildTests.AccessRemovedChildByReference" type="XmlDocumentTests.XmlNodeTests.RemoveChildTests" method="AccessRemovedChildByReference" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.RemoveChildTests.Whitespace_Comment_Text" type="XmlDocumentTests.XmlNodeTests.RemoveChildTests" method="Whitespace_Comment_Text" time="0,003" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.RemoveChildTests.NotChildNode" type="XmlDocumentTests.XmlNodeTests.RemoveChildTests" method="NotChildNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetElementsByTagNameTests.CreateElementAndFind" type="XmlDocumentTests.XmlElementTests.GetElementsByTagNameTests" method="CreateElementAndFind" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertBeforeTests.InsertAttributeNodeToAttributeNode" type="XmlDocumentTests.XmlNodeTests.InsertBeforeTests" method="InsertAttributeNodeToAttributeNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertTests.OneElementTests.Whitespace" type="XmlDocumentTests.XmlNodeTests.InsertTests.OneElementTests" method="Whitespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetAttributeTests.GetEmptyAttribute" type="XmlDocumentTests.XmlElementTests.GetAttributeTests" method="GetEmptyAttribute" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.HasAttributeTests.InvalidExistingNamespace" type="XmlDocumentTests.XmlElementTests.HasAttributeTests" method="InvalidExistingNamespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NameTests.NameOfAttribute" type="XmlDocumentTests.XmlNodeTests.NameTests" method="NameOfAttribute" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NextSiblingTests.OnDocumentFragment" type="XmlDocumentTests.XmlNodeTests.NextSiblingTests" method="OnDocumentFragment" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlProcessingInstructionTests.TargetTests.TargetTest1" type="XmlDocumentTests.XmlProcessingInstructionTests.TargetTests" method="TargetTest1" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertTests.ThreeElementTests.Text_Element_Text" type="XmlDocumentTests.XmlNodeTests.InsertTests.ThreeElementTests" method="Text_Element_Text" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.RemoveAttributeNodeTests.CallWithNull" type="XmlDocumentTests.XmlElementTests.RemoveAttributeNodeTests" method="CallWithNull" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NodeTypeTests.CommentNodeTypeTest" type="XmlDocumentTests.XmlNodeTests.NodeTypeTests" method="CommentNodeTypeTest" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NamespaceURITests.CloneAttributeXmlns" type="XmlDocumentTests.XmlNodeTests.NamespaceURITests" method="CloneAttributeXmlns" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.AppendChildTests.CallAppendChildOnTextNode" type="XmlDocumentTests.XmlNodeTests.AppendChildTests" method="CallAppendChildOnTextNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.SetAttributeNodeTests.ElementWithNoAttributes" type="XmlDocumentTests.XmlElementTests.SetAttributeNodeTests" method="ElementWithNoAttributes" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NextSiblingTests.NewlyCreatedCDataNode" type="XmlDocumentTests.XmlNodeTests.NextSiblingTests" method="NewlyCreatedCDataNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.NodeInsertedTests.InsertNodeBefore" type="XmlDocumentTests.XmlDocumentTests.NodeInsertedTests" method="InsertNodeBefore" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.HasChildNodesTests.ReplaceNodeWithChildrenWithEmptyNode" type="XmlDocumentTests.XmlNodeTests.HasChildNodesTests" method="ReplaceNodeWithChildrenWithEmptyNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.HasChildNodesTests.RemoveOnlyChildOfNode" type="XmlDocumentTests.XmlNodeTests.HasChildNodesTests" method="RemoveOnlyChildOfNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PrefixTests.LoadPrefix" type="XmlDocumentTests.XmlNodeTests.PrefixTests" method="LoadPrefix" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetElementsByTagNameTests.GetByTagnameEqualsRootNodeName" type="XmlDocumentTests.XmlElementTests.GetElementsByTagNameTests" method="GetByTagnameEqualsRootNodeName" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NameTests.ElementWithAttribute" type="XmlDocumentTests.XmlNodeTests.NameTests" method="ElementWithAttribute" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NextSiblingTests.OnAttributeNode" type="XmlDocumentTests.XmlNodeTests.NextSiblingTests" method="OnAttributeNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ChildNodesTests.AddChildNode" type="XmlDocumentTests.XmlNodeTests.ChildNodesTests" method="AddChildNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.DataTests.MoveTextNodeWithMuchWhiteSpace" type="XmlDocumentTests.XmlCharacterDataTests.DataTests" method="MoveTextNodeWithMuchWhiteSpace" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.ReplaceTests.Replace4CharactersFromCdataNodeFromBeginning" type="XmlDocumentTests.XmlCharacterDataTests.ReplaceTests" method="Replace4CharactersFromCdataNodeFromBeginning" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.CloneNodeTests.CloneRemovedAttributeNode" type="XmlDocumentTests.XmlNodeTests.CloneNodeTests" method="CloneRemovedAttributeNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NextSiblingTests.OnCommentNode" type="XmlDocumentTests.XmlNodeTests.NextSiblingTests" method="OnCommentNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ReplaceChildTests.ReplaceElementWithDocumentFragmentNode" type="XmlDocumentTests.XmlNodeTests.ReplaceChildTests" method="ReplaceElementWithDocumentFragmentNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.NodeInsertedTests.CreateElementAndModifyInnerText" type="XmlDocumentTests.XmlDocumentTests.NodeInsertedTests" method="CreateElementAndModifyInnerText" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.HasChildNodesTests.ElementWithManyChildren" type="XmlDocumentTests.XmlNodeTests.HasChildNodesTests" method="ElementWithManyChildren" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.RemoveChildTests.OldChildIsFirstChild" type="XmlDocumentTests.XmlNodeTests.RemoveChildTests" method="OldChildIsFirstChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NormalizeTests.EmptyWork" type="XmlDocumentTests.XmlNodeTests.NormalizeTests" method="EmptyWork" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetAttributeNodeTests.CreateAttributeWithNamespaceNode" type="XmlDocumentTests.XmlElementTests.GetAttributeNodeTests" method="CreateAttributeWithNamespaceNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertTests.OneElementTests.Text" type="XmlDocumentTests.XmlNodeTests.InsertTests.OneElementTests" method="Text" time="0,002" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ValueTests.CommentNode" type="XmlDocumentTests.XmlNodeTests.ValueTests" method="CommentNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ValueTests.AttributeNode" type="XmlDocumentTests.XmlNodeTests.ValueTests" method="AttributeNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LastChildTests.ElementWithTwoAttributes" type="XmlDocumentTests.XmlNodeTests.LastChildTests" method="ElementWithTwoAttributes" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.NodeRemovingTests.RemoveNode" type="XmlDocumentTests.XmlDocumentTests.NodeRemovingTests" method="RemoveNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.AttributesTests.GetAttributesOnProcessingInstruction" type="XmlDocumentTests.XmlNodeTests.AttributesTests" method="GetAttributesOnProcessingInstruction" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ValueTests.ProcessingInstructionNode" type="XmlDocumentTests.XmlNodeTests.ValueTests" method="ProcessingInstructionNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LocalNameTests.AllNodesForEmptyString" type="XmlDocumentTests.XmlNodeTests.LocalNameTests" method="AllNodesForEmptyString" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.RemoveChildTests.Text_Text_Text" type="XmlDocumentTests.XmlNodeTests.RemoveChildTests" method="Text_Text_Text" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.RemoveChildTests.OldChildIsNull" type="XmlDocumentTests.XmlNodeTests.RemoveChildTests" method="OldChildIsNull" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NextSiblingTests.NewlyCreatedDocumentFragment" type="XmlDocumentTests.XmlNodeTests.NextSiblingTests" method="NewlyCreatedDocumentFragment" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ParentNodeTests.MultipleTypesInComplexDocument" type="XmlDocumentTests.XmlNodeTests.ParentNodeTests" method="MultipleTypesInComplexDocument" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.RemoveAttributeNodeTests.WrongNamespace" type="XmlDocumentTests.XmlElementTests.RemoveAttributeNodeTests" method="WrongNamespace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.ImportNodeTests.ImportNullNode" type="XmlDocumentTests.XmlDocumentTests.ImportNodeTests" method="ImportNullNode" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.NodeChangingTests.RemoveNode" type="XmlDocumentTests.XmlDocumentTests.NodeChangingTests" method="RemoveNode" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlAttributeTests.OwnerDocumentTests.VerifyAllTypes" type="XmlDocumentTests.XmlAttributeTests.OwnerDocumentTests" method="VerifyAllTypes" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.RemoveAttributeNodeTests.GetElements" type="XmlDocumentTests.XmlElementTests.RemoveAttributeNodeTests" method="GetElements" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.CloneNodeTests.CloneComplexDocumentTrue" type="XmlDocumentTests.XmlNodeTests.CloneNodeTests" method="CloneComplexDocumentTrue" time="0,003" result="Pass" />
+    </collection>
+    <collection total="449" passed="449" failed="0" skipped="0" name="xUnit.net v1 Tests for D:\Dev\corefx\bin\Release\System.Xml.XmlDocument.Tests\System.Xml.XmlDocument.Tests.dll" time="0,215">
+      <test name="XmlDocumentTests.XmlAttributeTests.SpecifiedTests.AttributeSpecifiedTest" type="XmlDocumentTests.XmlAttributeTests.SpecifiedTests" method="AttributeSpecifiedTest" time="0,133" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.NodeInsertingTests.InsertNodeBefore" type="XmlDocumentTests.XmlDocumentTests.NodeInsertingTests" method="InsertNodeBefore" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.ParentNodeTests.NewlyCreatedDocumentFragment" type="XmlDocumentTests.XmlNodeTests.ParentNodeTests" method="NewlyCreatedDocumentFragment" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlCharacterDataTests.InsertDataTests.InsertDataBeyondEndOfCdataNodeBigNumber" type="XmlDocumentTests.XmlCharacterDataTests.InsertDataTests" method="InsertDataBeyondEndOfCdataNodeBigNumber" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests.SiblingOfLastChild" type="XmlDocumentTests.XmlNodeTests.PreviousSiblingTests" method="SiblingOfLastChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlImplementationTests.HasFeatureTests.TestForFeatureSome" type="XmlDocumentTests.XmlImplementationTests.HasFeatureTests" method="TestForFeatureSome" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.InsertTests.TwoElementTests.Comment_CDATA" type="XmlDocumentTests.XmlNodeTests.InsertTests.TwoElementTests" method="Comment_CDATA" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.AttributesTests.GetAttributesOnAttribute" type="XmlDocumentTests.XmlNodeTests.AttributesTests" method="GetAttributesOnAttribute" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.ImportNodeTests.ImportElementDeepTrue" type="XmlDocumentTests.XmlDocumentTests.ImportNodeTests" method="ImportElementDeepTrue" time="0,001" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlDocumentTests.ImportNodeTests.ImportWhiteSpace" type="XmlDocumentTests.XmlDocumentTests.ImportNodeTests" method="ImportWhiteSpace" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.NamespaceURITests.CreateAttributeXmlns" type="XmlDocumentTests.XmlNodeTests.NamespaceURITests" method="CreateAttributeXmlns" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlNodeTests.LastChildTests.ElementWithOneChild" type="XmlDocumentTests.XmlNodeTests.LastChildTests" method="ElementWithOneChild" time="0,000" result="Pass" />
+    </collection>
+    <collection>
+      <test name="XmlDocumentTests.XmlElementTests.GetAttributeTests.SetAttributeAndGetIt" type="XmlDocumentTests.XmlElementTests.GetAttributeTests" method="SetAttributeAndGetIt" time="0,000" result="Pass" />
+    </collection>
+  </assembly>
+</assemblies>


### PR DESCRIPTION
Using Windows Server 2008 R2 Datacenter and Mono 4.6.1 the debugger
would fail when starting debugging. The fail was caused by not been able
to find the pdb2mdb.bat file to convert the pdb files. THe reason been
it was looking in the wrong place int he registry
software/novell/mono/{version} but mono now seems to install with just
software/mono and no version number.

The fix i have submitted preserves the novell registry search as i
presume this is for older mono installs, but works with the new registry
entries.
